### PR TITLE
Regenerate clients and repair demo server tests

### DIFF
--- a/reflectapi-demo/clients/rust/generated/src/generated.rs
+++ b/reflectapi-demo/clients/rust/generated/src/generated.rs
@@ -11,7 +11,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     pub health: HealthInterface<E, C>,
     pub pets: PetsInterface<E, C>,
@@ -32,7 +32,7 @@ impl<E, C: super::Client<E> + Clone> Interface<E, C> {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct HealthInterface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -54,7 +54,7 @@ impl<E, C: super::Client<E> + Clone> HealthInterface<E, C> {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct PetsInterface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -155,7 +155,7 @@ pub mod types {
 pub mod myapi {
 pub mod model {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub enum Behavior {
     Calm,
     Aggressive(
@@ -174,7 +174,7 @@ pub enum Behavior {
     },
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub enum Kind {
     /// A dog
     #[serde(rename = "dog")]
@@ -184,7 +184,7 @@ pub enum Kind {
     Cat,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct Pet {
     /// identity
     pub name: std::string::String,
@@ -201,12 +201,12 @@ pub struct Pet {
 }
 pub mod proto {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct Headers {
     pub authorization: std::string::String,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct Paginated<T> {
     /// slice of a collection
     pub items: std::vec::Vec<T>,
@@ -215,7 +215,7 @@ pub struct Paginated<T> {
     pub cursor: std::option::Option<std::string::String>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub enum PetsCreateError {
     Conflict,
     NotAuthorized,
@@ -226,13 +226,13 @@ pub enum PetsCreateError {
 
 pub type PetsCreateRequest = super::super::myapi::model::Pet;
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub enum PetsListError {
     InvalidCustor,
     Unauthorized,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct PetsListRequest {
     #[serde(default, skip_serializing_if = "std::option::Option::is_none")]
     pub limit: std::option::Option<u8>,
@@ -240,25 +240,25 @@ pub struct PetsListRequest {
     pub cursor: std::option::Option<std::string::String>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub enum PetsRemoveError {
     NotFound,
     NotAuthorized,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct PetsRemoveRequest {
     /// identity
     pub name: std::string::String,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub enum PetsUpdateError {
     NotFound,
     NotAuthorized,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct PetsUpdateRequest {
     /// identity
     pub name: std::string::String,
@@ -273,7 +273,7 @@ pub struct PetsUpdateRequest {
     pub behaviors: reflectapi::Option<std::vec::Vec<super::super::myapi::model::Behavior>>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct UnauthorizedError;
 
 }

--- a/reflectapi-demo/clients/typescript/generated.ts
+++ b/reflectapi-demo/clients/typescript/generated.ts
@@ -97,7 +97,7 @@ export class Result<T, E> {
         if ('ok' in this.value) {
             return this.value.ok;
         }
-        throw new Error('called `unwrap_ok` on an `err` value: ' + this.value.err?.toString());
+        throw new Error(`called \`unwrap_ok\` on an \`err\` value: ${this.value.err}`);
     }
     public unwrap_err(): E {
         if ('err' in this.value) {
@@ -306,7 +306,7 @@ export type UnauthorizedError = null;
 
 }
 
-export namespace reflect {
+export namespace reflectapi {
 
 /// Struct object with no fields
 export interface Empty {
@@ -352,7 +352,7 @@ export function __request<I, H, O, E>(client: Client, path: string, input: I | u
                 try {
                     parsed_response_body = JSON.parse(response_body)
                 } catch (e) {
-                    return new Result<O, Err<E>>({ err: new Err({ other_err: response_body }) });
+                    return new Result<O, Err<E>>({ err: new Err({ other_err: `[${status}] ${response_body}` }) });
                 }
                 return new Result<O, Err<E>>({ err: new Err({ application_err: parsed_response_body as E }) });
             }
@@ -379,12 +379,12 @@ class ClientInstance {
     constructor(private base: string) {}
 
     public request(path: string, body: string, headers: Record<string, string>): Promise<[number, string]> {
-        return fetch(`${this.base}/${path}`, {
+        return (globalThis as any).fetch(`${this.base}${path}`, {
             method: 'POST',
             headers: headers,
             body: body,
-        }).then((response) => {
-            return response.text().then((text) => {
+        }).then((response: any) => {
+            return response.text().then((text: string) => {
                 return [response.status, text];
             });
         });
@@ -394,32 +394,32 @@ class ClientInstance {
 function health__check(client: Client) {
     return (input: {}, headers: {}) => __request<
         {}, {}, {}, {}
-    >(client, 'health.check', input, headers);
+    >(client, '/health.check', input, headers);
 }
 function pets__list(client: Client) {
     return (input: myapi.proto.PetsListRequest, headers: myapi.proto.Headers) => __request<
         myapi.proto.PetsListRequest, myapi.proto.Headers, myapi.proto.Paginated<myapi.model.Pet>, myapi.proto.PetsListError
-    >(client, 'pets.list', input, headers);
+    >(client, '/pets.list', input, headers);
 }
 function pets__create(client: Client) {
     return (input: myapi.proto.PetsCreateRequest, headers: myapi.proto.Headers) => __request<
         myapi.proto.PetsCreateRequest, myapi.proto.Headers, {}, myapi.proto.PetsCreateError
-    >(client, 'pets.create', input, headers);
+    >(client, '/pets.create', input, headers);
 }
 function pets__update(client: Client) {
     return (input: myapi.proto.PetsUpdateRequest, headers: myapi.proto.Headers) => __request<
         myapi.proto.PetsUpdateRequest, myapi.proto.Headers, {}, myapi.proto.PetsUpdateError
-    >(client, 'pets.update', input, headers);
+    >(client, '/pets.update', input, headers);
 }
 function pets__remove(client: Client) {
     return (input: myapi.proto.PetsRemoveRequest, headers: myapi.proto.Headers) => __request<
         myapi.proto.PetsRemoveRequest, myapi.proto.Headers, {}, myapi.proto.PetsRemoveError
-    >(client, 'pets.remove', input, headers);
+    >(client, '/pets.remove', input, headers);
 }
 function pets__get_first(client: Client) {
     return (input: {}, headers: myapi.proto.Headers) => __request<
         {}, myapi.proto.Headers, myapi.model.Pet | null, myapi.proto.UnauthorizedError
-    >(client, 'pets.get-first', input, headers);
+    >(client, '/pets.get-first', input, headers);
 }
 
 }

--- a/reflectapi-demo/src/tests/assert.rs
+++ b/reflectapi-demo/src/tests/assert.rs
@@ -82,7 +82,7 @@ where
     I: reflectapi::Input + serde::de::DeserializeOwned + Send + 'static,
 {
     let eps = into_input_schema::<I>();
-    reflectapi::codegen::rust::generate(eps).unwrap()
+    reflectapi::codegen::rust::generate(eps, vec![]).unwrap()
 }
 
 pub fn into_output_rust_code<O>() -> String
@@ -90,7 +90,7 @@ where
     O: reflectapi::Output + serde::ser::Serialize + Send + 'static,
 {
     let eps = into_output_schema::<O>();
-    reflectapi::codegen::rust::generate(eps).unwrap()
+    reflectapi::codegen::rust::generate(eps, vec![]).unwrap()
 }
 
 pub fn into_rust_code<T>() -> String
@@ -103,7 +103,7 @@ where
         + 'static,
 {
     let eps = into_schema::<T>();
-    reflectapi::codegen::rust::generate(eps).unwrap()
+    reflectapi::codegen::rust::generate(eps, vec![]).unwrap()
 }
 
 macro_rules! assert_input_snapshot {

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_enum_documented-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_enum_documented-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -101,7 +101,7 @@ pub mod basic {
 
 /// Some Enum docs
 /// more
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub enum TestEnumDocumented<T> {
     /// Variant1 docs
     Variant1(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_documented-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_documented-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -102,7 +102,7 @@ pub mod basic {
 /// Some Struct docs
 /// more
 /// more
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructDocumented {
     /// field docs
     /// multiline

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_empty-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_empty-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructEmpty {
 }
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_newtype-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_newtype-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructOneBasicFieldString {
     pub _f: std::string::String,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructOneBasicFieldStringReflectBoth {
     pub _f: std::string::String,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructOneBasicFieldStringReflectBothEqually {
     pub _f: u32,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally2-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally2-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructOneBasicFieldStringReflectBothEqually {
     pub _f: u32,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_with_attributes-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_with_attributes-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -100,7 +100,7 @@ pub mod tests {
 pub mod basic {
 pub mod input {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructOneBasicFieldStringReflectBothDifferently {
     pub _f: i32,
 }
@@ -108,7 +108,7 @@ pub struct TestStructOneBasicFieldStringReflectBothDifferently {
 }
 pub mod output {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct TestStructOneBasicFieldStringReflectBothDifferently {
     pub _f: u32,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_u32-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_u32-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructOneBasicFieldU32 {
     pub _f: u32,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_option-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_option-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructOption {
     pub _f: std::option::Option<u8>,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_tuple-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_tuple-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructTuple (
     u8,
     std::string::String,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_unit_type-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_unit_type-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructUnitType;
 
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_all_primitive_type_fields-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_all_primitive_type_fields-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithAllPrimitiveTypeFields {
     pub _f_u8: u8,
     pub _f_u16: u16,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithArc {
     pub _f: std::sync::Arc<u8>,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc_pointer_only-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc_pointer_only-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithArcPointerOnly {
     pub _f_pointer_arc: std::sync::Arc<u8>,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_input_only-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_input_only-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -105,7 +105,7 @@ pub type TestStructWithAttributesInputOnly = std::string::String;
 }
 pub mod output {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct TestStructWithAttributesInputOnly {
     pub _f: std::string::String,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_output_only-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_output_only-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -100,7 +100,7 @@ pub mod tests {
 pub mod basic {
 pub mod input {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithAttributesOutputOnly {
     pub _f: std::string::String,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_type_only-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_type_only-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_fixed_size_array-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_fixed_size_array-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithFixedSizeArray {
     pub _f: std::array::Array<u8, 3>,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashmap-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashmap-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithHashMap {
     pub _f: std::collections::HashMap<u8, std::string::String>,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithHashSetField {
     pub _f_hashset: std::collections::HashSet<u8>,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field_generic-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field_generic-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithHashSetFieldGeneric<G> {
     pub _f_hashset: std::collections::HashSet<G>,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,14 +99,14 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructNested {
     pub _f: std::string::String,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithNested {
-    pub _f: super::super::reflectapi_demo::tests::basic::TestStructNested,
+    pub _f: super::super::super::reflectapi_demo::tests::basic::TestStructNested,
 }
 
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested_external-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested_external-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,15 +99,15 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithNestedExternal {
-    pub _f: super::super::reflectapi_demo::tests::test_lib::TestStructNested,
+    pub _f: super::super::super::reflectapi_demo::tests::test_lib::TestStructNested,
 }
 
 }
 pub mod test_lib {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructNested {
     pub _f: std::string::String,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_self_via_arc-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_self_via_arc-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,9 +99,9 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithSelfViaArc {
-    pub _f: std::sync::Arc<super::super::reflectapi_demo::tests::basic::TestStructWithSelfViaArc>,
+    pub _f: std::sync::Arc<super::super::super::reflectapi_demo::tests::basic::TestStructWithSelfViaArc>,
 }
 
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithSkipField {
 }
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_input-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_input-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -100,14 +100,14 @@ pub mod tests {
 pub mod basic {
 pub mod input {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithSkipFieldInput {
 }
 
 }
 pub mod output {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct TestStructWithSkipFieldInput {
     pub _f: u8,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_output-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_output-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -100,7 +100,7 @@ pub mod tests {
 pub mod basic {
 pub mod input {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithSkipFieldOutput {
     pub _f: u8,
 }
@@ -108,7 +108,7 @@ pub struct TestStructWithSkipFieldOutput {
 }
 pub mod output {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct TestStructWithSkipFieldOutput {
 }
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_array-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_array-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithTransformArray {
     pub _f: std::vec::Vec<u8>,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_both-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_both-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithTransformBoth {
     pub _f: u8,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithTransformFallback {
     pub _f: u8,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback_nested-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback_nested-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithTransformFallbackNested {
     pub _f: u8,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_input-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_input-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -100,7 +100,7 @@ pub mod tests {
 pub mod basic {
 pub mod input {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithTransformInput {
     pub _f: u8,
 }
@@ -108,7 +108,7 @@ pub struct TestStructWithTransformInput {
 }
 pub mod output {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct TestStructWithTransformInput {
     pub _f: std::sync::Arc<u8>,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_output-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_output-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -100,7 +100,7 @@ pub mod tests {
 pub mod basic {
 pub mod input {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithTransformOutput {
     pub _f: std::sync::Arc<u8>,
 }
@@ -108,7 +108,7 @@ pub struct TestStructWithTransformOutput {
 }
 pub mod output {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct TestStructWithTransformOutput {
     pub _f: u8,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithTuple {
     pub _f: (u8, std::string::String),
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple12-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple12-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithTuple12 {
     pub _f: (u8, std::string::String, u8, std::string::String, u8, std::string::String, u8, std::string::String, u8, u80, u81, u82),
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithVec {
     pub _f: std::vec::Vec<u8>,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_external-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_external-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,15 +99,15 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithVecExternal {
-    pub _f: std::vec::Vec<super::super::reflectapi_demo::tests::test_lib::TestStructNested>,
+    pub _f: std::vec::Vec<super::super::super::reflectapi_demo::tests::test_lib::TestStructNested>,
 }
 
 }
 pub mod test_lib {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructNested {
     pub _f: std::string::String,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_nested-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_nested-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,15 +99,15 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithVecNested {
-    pub _f: std::vec::Vec<std::vec::Vec<super::super::reflectapi_demo::tests::test_lib::TestStructNested>>,
+    pub _f: std::vec::Vec<std::vec::Vec<super::super::super::reflectapi_demo::tests::test_lib::TestStructNested>>,
 }
 
 }
 pub mod test_lib {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructNested {
     pub _f: std::string::String,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_two-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_two-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod basic {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithVecTwo {
     pub _f: std::vec::Vec<u8>,
     pub _f2: std::vec::Vec<i8>,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod enums {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub enum TestEnum {
     Variant1,
     Variant2,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_empty-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_empty-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod enums {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub enum TestEnumEmpty {
 }
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_basic_variant_and_fields_and_named_fields-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_basic_variant_and_fields_and_named_fields-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod enums {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub enum TestEnumWithBasicVariantAndFieldsAndNamedFields {
     Variant0,
     Variant1(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_ignored_input-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_ignored_input-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod enums {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub enum TestEnumWithDiscriminantIgnored {
     Variant1,
     Variant2,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_ignored_output-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_ignored_output-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod enums {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub enum TestEnumWithDiscriminantIgnored {
     Variant1,
     Variant2,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_input-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_input-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod enums {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub enum TestEnumWithDiscriminant {
     Variant1 = 1,
     Variant2 = 2,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_output-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_output-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod enums {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub enum TestEnumWithDiscriminant {
     Variant1 = 1,
     Variant2 = 2,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_empty_variant_and_fields-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_empty_variant_and_fields-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod enums {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub enum TestEnumWithEmptyVariantAndFields {
     Variant1,
     Variant2(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_fields-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_fields-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod enums {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub enum TestEnumWithFields {
     Variant1(
         u8,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod enums {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub enum TestEnumWithGenerics<T> {
     Variant1(
         T,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod enums {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub enum TestEnumWithGenericsAndFields<T> {
     Variant1(
         u8,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields_and_named_fields-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields_and_named_fields-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod enums {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub enum TestEnumWithGenericsAndFieldsAndNamedFields<T> {
     Variant1(
         u8,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,9 +99,9 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod generics {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithCircularReference {
-    pub _f: std::boxed::Box<super::super::reflectapi_demo::tests::generics::TestStructWithCircularReference>,
+    pub _f: std::boxed::Box<super::super::super::reflectapi_demo::tests::generics::TestStructWithCircularReference>,
 }
 
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,9 +99,9 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod generics {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithCircularReferenceGeneric<T> {
-    pub _f: std::boxed::Box<super::super::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGeneric<T>>,
+    pub _f: std::boxed::Box<super::super::super::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGeneric<T>>,
     pub _f2: T,
 }
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_parent-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_parent-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,15 +99,15 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod generics {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithCircularReferenceGeneric<T> {
-    pub _f: std::boxed::Box<super::super::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGeneric<T>>,
+    pub _f: std::boxed::Box<super::super::super::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGeneric<T>>,
     pub _f2: T,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithCircularReferenceGenericParent<T> {
-    pub _f: std::boxed::Box<super::super::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGeneric<super::super::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericParent<T>>>,
+    pub _f: std::boxed::Box<super::super::super::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGeneric<super::super::super::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericParent<T>>>,
     pub _f2: std::marker::PhantomData<T>,
 }
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod generics {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithCircularReferenceGenericWithoutBox<A, B> {
     pub _f1: A,
     pub _f2: B,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,15 +99,15 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod generics {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithCircularReferenceGenericWithoutBox<A, B> {
     pub _f1: A,
     pub _f2: B,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithCircularReferenceGenericWithoutBoxParent<C, D> {
-    pub _f: super::super::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBox<D, C>,
+    pub _f: super::super::super::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBox<D, C>,
 }
 
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent_specific-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent_specific-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,15 +99,15 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod generics {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithCircularReferenceGenericWithoutBox<A, B> {
     pub _f1: A,
     pub _f2: B,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithCircularReferenceGenericWithoutBoxParentSpecific {
-    pub _f: super::super::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBox<super::super::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBox<u8, u16>, super::super::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBox<std::string::String, u32>>,
+    pub _f: super::super::super::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBox<super::super::super::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBox<u8, u16>, super::super::super::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBox<std::string::String, u32>>,
 }
 
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,12 +99,12 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod generics {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithNestedGenericStruct {
-    pub _f: super::super::reflectapi_demo::tests::generics::TestStructWithSimpleGeneric<super::super::reflectapi_demo::tests::generics::TestStructWithSimpleGeneric<u8>>,
+    pub _f: super::super::super::reflectapi_demo::tests::generics::TestStructWithSimpleGeneric<super::super::super::reflectapi_demo::tests::generics::TestStructWithSimpleGeneric<u8>>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithSimpleGeneric<A> {
     pub _f: A,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct_twice-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct_twice-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,13 +99,13 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod generics {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithNestedGenericStructTwice {
-    pub _f: super::super::reflectapi_demo::tests::generics::TestStructWithSimpleGeneric<u8>,
-    pub _f2: super::super::reflectapi_demo::tests::generics::TestStructWithSimpleGeneric<std::string::String>,
+    pub _f: super::super::super::reflectapi_demo::tests::generics::TestStructWithSimpleGeneric<u8>,
+    pub _f2: super::super::super::reflectapi_demo::tests::generics::TestStructWithSimpleGeneric<std::string::String>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithSimpleGeneric<A> {
     pub _f: A,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_simple_generic-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_simple_generic-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod generics {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithSimpleGeneric<A> {
     pub _f: A,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod generics {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithVecGeneric<T> {
     pub _f: std::vec::Vec<T>,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,14 +99,14 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod generics {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithSimpleGeneric<A> {
     pub _f: A,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithVecGenericGeneric<T> {
-    pub _f: std::vec::Vec<super::super::reflectapi_demo::tests::generics::TestStructWithSimpleGeneric<T>>,
+    pub _f: std::vec::Vec<super::super::super::reflectapi_demo::tests::generics::TestStructWithSimpleGeneric<T>>,
 }
 
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic_generic-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic_generic-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,14 +99,14 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod generics {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithVecGeneric<T> {
     pub _f: std::vec::Vec<T>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithVecGenericGenericGeneric<T> {
-    pub _f: std::vec::Vec<super::super::reflectapi_demo::tests::generics::TestStructWithVecGeneric<T>>,
+    pub _f: std::vec::Vec<super::super::super::reflectapi_demo::tests::generics::TestStructWithVecGeneric<T>>,
 }
 
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub enum MyEnum {
     V1,
     V2,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub enum TestEnumRenameAll {
     #[serde(rename = "fieldName")]
     FieldName,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all_on_variant-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all_on_variant-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub enum TestEnumRenameAllOnVariant {
     Variant1 {
         #[serde(rename = "fieldName")]

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_variant_field-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_variant_field-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub enum TestEnumRenameVariantField {
     Variant1 {
         variant1_field_name: u8,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "type")]
     pub enum TestEnumTag {
     Variant1 {

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "type", content = "content")]
     pub enum TestEnumTagContent {
     Variant1 {

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content_rename_all-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content_rename_all-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "type", content = "content")]
     pub enum TestEnumTagContentRenameAll {
     #[serde(rename = "variant1")]

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_untagged-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_untagged-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[serde(untagged)]
     pub enum TestEnumUntagged {
     Variant1(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_field_skip-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_field_skip-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub enum TestEnumWithFieldSkip {
     Variant1,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_rename_to_invalid_chars-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_rename_to_invalid_chars-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub enum TestEnumWithRenameToInvalidChars {
     #[serde(rename = "variant-name&&")]
     Variant1 {

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_other-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_other-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -100,7 +100,7 @@ pub mod tests {
 pub mod serde {
 pub mod input {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 #[serde(tag = "type")]
     pub enum TestEnumWithVariantOther {
     V0,
@@ -109,7 +109,7 @@ pub mod input {
 }
 pub mod output {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[serde(tag = "type")]
     pub enum TestEnumWithVariantOther {
     V0,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub enum TestEnumWithVariantSkip {
 }
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_deserialize-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_deserialize-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -100,14 +100,14 @@ pub mod tests {
 pub mod serde {
 pub mod input {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub enum TestEnumWithVariantSkipDeserialize {
 }
 
 }
 pub mod output {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub enum TestEnumWithVariantSkipDeserialize {
     #[serde(rename = "_Variant1")]
     Variant1,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_serialize-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_serialize-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -100,7 +100,7 @@ pub mod tests {
 pub mod serde {
 pub mod input {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub enum TestEnumWithVariantSkipSerialize {
     Variant1,
 }
@@ -108,7 +108,7 @@ pub enum TestEnumWithVariantSkipSerialize {
 }
 pub mod output {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub enum TestEnumWithVariantSkipSerialize {
 }
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_untagged-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_untagged-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub enum TestEnumWithVariantUntagged {
     #[serde(untagged)]
     Variant1(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_from-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_from-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,18 +99,18 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructFrom {
     pub f: u8,
 }
 pub mod input {
 
-pub type TestStructFromProxy = super::super::reflectapi_demo::tests::serde::TestStructFrom;
+pub type TestStructFromProxy = super::super::super::super::reflectapi_demo::tests::serde::TestStructFrom;
 
 }
 pub mod output {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct TestStructFromProxy {
     pub f: u8,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_into-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_into-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,13 +99,13 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct TestStructInto {
     pub f: u8,
 }
 pub mod input {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructIntoProxy {
     pub f: u8,
 }
@@ -113,7 +113,7 @@ pub struct TestStructIntoProxy {
 }
 pub mod output {
 
-pub type TestStructIntoProxy = super::super::reflectapi_demo::tests::serde::TestStructInto;
+pub type TestStructIntoProxy = super::super::super::super::reflectapi_demo::tests::serde::TestStructInto;
 
 }
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct MyStruct {
 }
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructRenameAll {
     #[serde(rename = "fieldName")]
     pub field_name: u8,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_differently-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_differently-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -100,7 +100,7 @@ pub mod tests {
 pub mod serde {
 pub mod input {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructRenameAllDifferently {
     pub field_name: u8,
 }
@@ -108,7 +108,7 @@ pub struct TestStructRenameAllDifferently {
 }
 pub mod output {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct TestStructRenameAllDifferently {
     #[serde(rename = "fieldName")]
     pub field_name: u8,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_pascal_case-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_pascal_case-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructRenameAllPascalCase {
     #[serde(rename = "FieldName")]
     pub field_name: u8,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_differently-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_differently-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,11 +99,11 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct MyStructInput {
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct MyStructOutput {
 }
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_field-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_field-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -100,7 +100,7 @@ pub mod tests {
 pub mod serde {
 pub mod input {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructRenameField {
     #[serde(rename = "fieldName")]
     pub field_name: u8,
@@ -109,7 +109,7 @@ pub struct TestStructRenameField {
 }
 pub mod output {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct TestStructRenameField {
     pub field_name: u8,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_try_from-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_try_from-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,18 +99,18 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructTryFrom {
     pub f: u8,
 }
 pub mod input {
 
-pub type TestStructTryFormProxy = super::super::reflectapi_demo::tests::serde::TestStructTryFrom;
+pub type TestStructTryFormProxy = super::super::super::super::reflectapi_demo::tests::serde::TestStructTryFrom;
 
 }
 pub mod output {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct TestStructTryFormProxy {
     pub f: u8,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,13 +99,13 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithFlatten {
-    #[serde(flattened)]
-    pub g: super::super::reflectapi_demo::tests::serde::TestStructWithFlattenNested,
+    #[serde(flatten)]
+    pub g: super::super::super::reflectapi_demo::tests::serde::TestStructWithFlattenNested,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithFlattenNested {
     pub f: u8,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,15 +99,15 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithFlattenNested {
     pub f: u8,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithFlattenOptional {
-    #[serde(default, skip_serializing_if = "std::option::Option::is_none", flattened)]
-    pub g: std::option::Option<super::super::reflectapi_demo::tests::serde::TestStructWithFlattenNested>,
+    #[serde(default, skip_serializing_if = "std::option::Option::is_none", flatten)]
+    pub g: std::option::Option<super::super::super::reflectapi_demo::tests::serde::TestStructWithFlattenNested>,
 }
 
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional_and_required-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional_and_required-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,23 +99,23 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructRenameAll {
     #[serde(rename = "fieldName")]
     pub field_name: u8,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithFlattenNested {
     pub f: u8,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithFlattenOptionalAndRequired {
-    #[serde(default, skip_serializing_if = "std::option::Option::is_none", flattened)]
-    pub g: std::option::Option<super::super::reflectapi_demo::tests::serde::TestStructWithFlattenNested>,
-    #[serde(flattened)]
-    pub k: super::super::reflectapi_demo::tests::serde::TestStructRenameAll,
+    #[serde(default, skip_serializing_if = "std::option::Option::is_none", flatten)]
+    pub g: std::option::Option<super::super::super::reflectapi_demo::tests::serde::TestStructWithFlattenNested>,
+    #[serde(flatten)]
+    pub k: super::super::super::reflectapi_demo::tests::serde::TestStructRenameAll,
 }
 
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_invalid_chars-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_invalid_chars-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithRenameToInvalidChars {
     #[serde(rename = "field-name&&")]
     pub f: u8,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_kebab_case-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_kebab_case-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct struct_name {
     #[serde(rename = "field-name")]
     pub field_name: u8,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_default-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_default-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -100,7 +100,7 @@ pub mod tests {
 pub mod serde {
 pub mod input {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithSerdeDefault {
     #[serde(default)]
     pub f: u8,
@@ -109,7 +109,7 @@ pub struct TestStructWithSerdeDefault {
 }
 pub mod output {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct TestStructWithSerdeDefault {
     pub f: u8,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -99,7 +99,7 @@ pub mod reflectapi_demo {
 pub mod tests {
 pub mod serde {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct TestStructWithSerdeSkip {
 }
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_deserialize-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_deserialize-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -100,14 +100,14 @@ pub mod tests {
 pub mod serde {
 pub mod input {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithSerdeSkipDeserialize {
 }
 
 }
 pub mod output {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct TestStructWithSerdeSkipDeserialize {
     pub f: u8,
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -100,7 +100,7 @@ pub mod tests {
 pub mod serde {
 pub mod input {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithSerdeSkipSerialize {
     pub _f: u8,
 }
@@ -108,7 +108,7 @@ pub struct TestStructWithSerdeSkipSerialize {
 }
 pub mod output {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct TestStructWithSerdeSkipSerialize {
 }
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize_if-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize_if-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,
@@ -100,7 +100,7 @@ pub mod tests {
 pub mod serde {
 pub mod input {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct TestStructWithSerdeSkipSerializeIf {
     pub f: std::option::Option<u8>,
 }
@@ -108,7 +108,7 @@ pub struct TestStructWithSerdeSkipSerializeIf {
 }
 pub mod output {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct TestStructWithSerdeSkipSerializeIf {
     #[serde(default, skip_serializing_if = "std::option::Option::is_none")]
     pub f: std::option::Option<u8>,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_transparent-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_transparent-3.snap
@@ -15,7 +15,7 @@ pub use interface::Interface;
 
 pub mod interface {
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Debug)]
 pub struct Interface<E, C: super::Client<E> + Clone> {
     client: C,
     base_url: std::string::String,


### PR DESCRIPTION
Certain changes in the library were not reflected in test code resulting in compile fails. Regenerated client definitions along the way to ensure they're current.
