### PR TITLE
codegen(rust) array syntax fix

### DIFF
--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_enum_documented-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_enum_documented-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_documented-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_documented-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_empty-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_empty-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_newtype-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_newtype-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally2-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally2-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_with_attributes-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_with_attributes-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_u32-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_u32-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_option-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_option-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_tuple-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_tuple-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_unit_type-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_unit_type-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_all_primitive_type_fields-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_all_primitive_type_fields-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 
@@ -302,7 +304,7 @@ export namespace reflectapi_demo {
           number /* u8 */,
           string,
         ];
-        _f_array: Array<number /* u8 */>;
+        _f_array: FixedSizeArray<number /* u8 */, 3>;
         _f_pointer_box: number /* u8 */;
         _f_pointer_arc: number /* u8 */;
         _f_pointer_cell: number /* u8 */;

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_all_primitive_type_fields-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_all_primitive_type_fields-3.snap
@@ -207,7 +207,7 @@ pub mod types {
                         u81,
                         u82,
                     ),
-                    pub _f_array: std::array::Array<u8, 3>,
+                    pub _f_array: [u8; 3],
                     pub _f_pointer_box: std::boxed::Box<u8>,
                     pub _f_pointer_arc: std::sync::Arc<u8>,
                     pub _f_pointer_cell: std::cell::Cell<u8>,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc_pointer_only-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc_pointer_only-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_input_only-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_input_only-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_output_only-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_output_only-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_type_only-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_type_only-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_fixed_size_array-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_fixed_size_array-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 
@@ -193,7 +195,7 @@ export namespace reflectapi_demo {
   export namespace tests {
     export namespace basic {
       export interface TestStructWithFixedSizeArray {
-        _f: Array<number /* u8 */>;
+        _f: FixedSizeArray<number /* u8 */, 3>;
       }
     }
   }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_fixed_size_array-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_fixed_size_array-3.snap
@@ -104,7 +104,7 @@ pub mod types {
 
                 #[derive(Debug, serde::Serialize, serde::Deserialize)]
                 pub struct TestStructWithFixedSizeArray {
-                    pub _f: std::array::Array<u8, 3>,
+                    pub _f: [u8; 3],
                 }
             }
         }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashmap-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashmap-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field_generic-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field_generic-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested_external-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested_external-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_self_via_arc-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_self_via_arc-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_input-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_input-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_output-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_output-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_array-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_array-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_both-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_both-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback_nested-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback_nested-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_input-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_input-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_output-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_output-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple12-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple12-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_external-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_external-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_nested-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_nested-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_two-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_two-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_empty-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_empty-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_basic_variant_and_fields_and_named_fields-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_basic_variant_and_fields_and_named_fields-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_ignored_input-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_ignored_input-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_ignored_output-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_ignored_output-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_input-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_input-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_output-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_output-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_empty_variant_and_fields-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_empty_variant_and_fields-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_fields-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_fields-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields_and_named_fields-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields_and_named_fields-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_parent-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_parent-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box-2.snap
@@ -40,6 +40,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent-2.snap
@@ -40,6 +40,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent_specific-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent_specific-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct_twice-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct_twice-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_simple_generic-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_simple_generic-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic_generic-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic_generic-2.snap
@@ -33,6 +33,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all_on_variant-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all_on_variant-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_variant_field-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_variant_field-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content_rename_all-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content_rename_all-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_untagged-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_untagged-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_field_skip-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_field_skip-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_rename_to_invalid_chars-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_rename_to_invalid_chars-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_other-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_other-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_deserialize-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_deserialize-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_serialize-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_serialize-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_untagged-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_untagged-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_from-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_from-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_into-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_into-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_differently-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_differently-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_pascal_case-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_pascal_case-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_differently-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_differently-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_field-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_field-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_try_from-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_try_from-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional_and_required-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional_and_required-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_invalid_chars-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_invalid_chars-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_kebab_case-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_kebab_case-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_default-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_default-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip-2.snap
@@ -31,6 +31,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_deserialize-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_deserialize-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize_if-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize_if-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_transparent-2.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_transparent-2.snap
@@ -34,6 +34,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi/src/codegen/rust.rs
+++ b/reflectapi/src/codegen/rust.rs
@@ -1152,6 +1152,8 @@ fn __build_implemented_types() -> HashMap<String, String> {
     // TODO this one should probably be defined as primitive type
     implemented_types.insert("reflectapi::Option".into(), "reflectapi::Option<T>".into());
 
+    implemented_types.insert("std::array::Array".into(), "[T; N]".into());
+
     // TODO the following could be declared via type aliases in the generated code or in the reflect api
     implemented_types.insert("std::tuple::Tuple1".into(), "(T1)".into());
     implemented_types.insert("std::tuple::Tuple2".into(), "(T1, T2)".into());

--- a/reflectapi/src/codegen/typescript.rs
+++ b/reflectapi/src/codegen/typescript.rs
@@ -131,6 +131,9 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
+
 export class Result<T, E> {
     constructor(private value: { ok: T } | { err: E }) {}
 
@@ -1101,6 +1104,7 @@ fn build_implemented_types() -> HashMap<String, String> {
     // the implementation of reflect for standard types
 
     implemented_types.insert("std::option::Option".into(), "T | null".into());
+    implemented_types.insert("std::array::Array".into(), "FixedSizeArray<T, N>".into());
     implemented_types.insert("reflectapi::Option".into(), "T | null | undefined".into());
 
     implemented_types.insert("std::vec::Vec".into(), "Array<T>".into());


### PR DESCRIPTION
Generate valid rust array syntax rather than `std::array::Array<T, N>`. This was just missing in `implemented_types`.

Typescript codegen has been changed to constrain the array lengths too.

Resolves #12 

Have discussed changes with @avkonst, technically breaking for the typescript codegen but minor.