### PR TITLE
Use serde_name to collect the set of `allowed_input_headers`

### DIFF
--- a/reflectapi/src/builder/handler.rs
+++ b/reflectapi/src/builder/handler.rs
@@ -59,9 +59,10 @@ where
             .input_types
             .get_type(&input_headers.name.as_str())
             .map(|type_def| match type_def {
-                crate::Type::Struct(Struct { fields, .. }) => {
-                    fields.iter().map(|field| field.name.clone()).collect()
-                }
+                crate::Type::Struct(Struct { fields, .. }) => fields
+                    .iter()
+                    .map(|field| field.serde_name().to_owned())
+                    .collect(),
                 _ => vec![],
             })
             .unwrap_or_default();


### PR DESCRIPTION
Prior to this serde case transformations would have been ignored and the
generated client definitions wouldn't match what the server expects.

Not sure if the existing test infrastructure can catch a bug like this so left it for now.

cc @elilabes, I think this is the source of the header issues you ran into.