### PR TITLE
CI: Globally install `prettier` to avoid using `npx`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
     name: Rust format, lint, and test
     runs-on: ubuntu-latest
     steps:
+      - run: npm install -g prettier
       - uses: actions/checkout@v4
       # https://github.com/actions-rs/toolchain
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Some flaky issues arise in CI that seem npx related.

https://github.com/thepartly/reflectapi/actions/runs/10312488341/job/28547791923