### PR TITLE
Bound each type parameter with `reflectapi::Input/Output` in derived impl

### DIFF
--- a/reflectapi-demo/tests/errors/invalid_reflect_type_generic.stderr
+++ b/reflectapi-demo/tests/errors/invalid_reflect_type_generic.stderr
@@ -6,25 +6,3 @@ error[E0392]: parameter `T` is never used
   |
   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
   = help: if you intended `T` to be a const parameter, use `const T: usize` instead
-
-error[E0277]: the trait bound `T: Input` is not satisfied
- --> tests/errors/invalid_reflect_type_generic.rs:2:17
-  |
-2 | struct MyStruct<T> {
-  |                 ^ the trait `Input` is not implemented for `T`
-  |
-help: consider restricting type parameter `T`
-  |
-2 | struct MyStruct<T: reflectapi::Input> {
-  |                  +++++++++++++++++++
-
-error[E0277]: the trait bound `T: reflectapi::Output` is not satisfied
- --> tests/errors/invalid_reflect_type_generic.rs:2:17
-  |
-2 | struct MyStruct<T> {
-  |                 ^ the trait `reflectapi::Output` is not implemented for `T`
-  |
-help: consider restricting type parameter `T`
-  |
-2 | struct MyStruct<T: reflectapi::Output> {
-  |                  ++++++++++++++++++++

--- a/reflectapi-demo/tests/success/reflect_generic_struct.rs
+++ b/reflectapi-demo/tests/success/reflect_generic_struct.rs
@@ -1,0 +1,4 @@
+#[derive(Debug, serde::Serialize, reflectapi::Input, reflectapi::Output)]
+pub struct Gen<T>(T);
+
+fn main() {}


### PR DESCRIPTION
Naturally this isn't a perfect derive and suffers from the usual issues,
but the common case should be where the bound is required.

Closes #11.
