### PR TITLE
cfg(builder) code is not allowed to depend on anyhow

### DIFF
--- a/reflectapi/src/builder/mod.rs
+++ b/reflectapi/src/builder/mod.rs
@@ -134,7 +134,7 @@ where
 
     pub fn build(
         mut self,
-    ) -> anyhow::Result<(crate::Schema, Vec<Router<S>>), Vec<crate::ValidationError>> {
+    ) -> std::result::Result<(crate::Schema, Vec<Router<S>>), Vec<crate::ValidationError>> {
         self.schema.input_types.sort_types();
         self.schema.output_types.sort_types();
 


### PR DESCRIPTION
This failed to build with `--no-default-features --features builder`. Have to use `std::result::Result` since there's another result in scope.