### PR TITLE
Avoid defining reflectapi::Result

### DIFF
--- a/reflectapi/src/builder/mod.rs
+++ b/reflectapi/src/builder/mod.rs
@@ -67,7 +67,7 @@ where
     where
         F: Fn(S, I, H) -> Fut + Send + Sync + Copy + 'static,
         Fut: std::future::Future<Output = R> + Send + 'static,
-        R: Into<crate::Result<O, E>> + 'static,
+        R: IntoResult<O, E> + 'static,
         I: crate::Input + serde::de::DeserializeOwned + Send + 'static,
         H: crate::Input + serde::de::DeserializeOwned + Send + 'static,
         O: crate::Output + serde::ser::Serialize + Send + 'static,

--- a/reflectapi/src/builder/result.rs
+++ b/reflectapi/src/builder/result.rs
@@ -2,60 +2,18 @@ pub trait StatusCode {
     fn status_code(&self) -> http::StatusCode;
 }
 
-#[derive(Debug, serde::Serialize)]
-#[serde(untagged)]
-pub enum Result<T, E>
-where
-    T: crate::Output,
-    E: crate::Output + StatusCode,
-{
-    Ok(T),
-    Err(E),
+pub trait IntoResult<O, E> {
+    fn into_result(self) -> Result<O, E>;
 }
 
-impl<T, E> Result<T, E>
-where
-    T: crate::Output,
-    E: crate::Output + StatusCode,
-{
-    pub fn status_code(&self) -> http::StatusCode {
-        match self {
-            Result::Ok(_) => http::StatusCode::OK,
-            Result::Err(e) => {
-                let custom_error = e.status_code();
-                if custom_error == http::StatusCode::OK {
-                    // It means a user has implemented ToStatusCode trait for their
-                    // type incorrectly. It is a protocol error to return 200 status
-                    // code for an error response, as the client will not be able
-                    // to "cast" the response body to the correct type.
-                    // So, we are reverting it to internal error
-                    http::StatusCode::INTERNAL_SERVER_ERROR
-                } else {
-                    custom_error
-                }
-            }
-        }
+impl<T: crate::Output> IntoResult<T, crate::Infallible> for T {
+    fn into_result(self) -> Result<T, crate::Infallible> {
+        Result::Ok(self)
     }
 }
 
-impl<T, E> From<std::result::Result<T, E>> for Result<T, E>
-where
-    T: crate::Output,
-    E: crate::Output + StatusCode,
-{
-    fn from(r: std::result::Result<T, E>) -> Self {
-        match r {
-            Ok(t) => Result::Ok(t),
-            Err(e) => Result::Err(e),
-        }
-    }
-}
-
-impl<T> From<T> for Result<T, crate::Infallible>
-where
-    T: crate::Output,
-{
-    fn from(t: T) -> Self {
-        Result::Ok(t)
+impl<T, E> IntoResult<T, E> for Result<T, E> {
+    fn into_result(self) -> Result<T, E> {
+        self
     }
 }


### PR DESCRIPTION
I think the better workaround is to define our own trait instead. I don't think this change should break any users as `reflectapi::Result` was mostly used internally.
