### PR TITLE
fix(codegen openapi): treat enum variants with a single field as transparent

### DIFF
--- a/reflectapi-demo/openapi.json
+++ b/reflectapi-demo/openapi.json
@@ -360,13 +360,7 @@
                 "properties": {}
               },
               {
-                "description": "The value is provided and set to some value",
-                "type": "array",
-                "prefixItems": [
-                  {
-                    "$ref": "#/components/schemas/u8"
-                  }
-                ]
+                "$ref": "#/components/schemas/u8"
               }
             ]
           },
@@ -383,17 +377,11 @@
                 "properties": {}
               },
               {
-                "description": "The value is provided and set to some value",
+                "description": "Expandable array type",
                 "type": "array",
-                "prefixItems": [
-                  {
-                    "description": "Expandable array type",
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/myapi.model.Behavior"
-                    }
-                  }
-                ]
+                "items": {
+                  "$ref": "#/components/schemas/myapi.model.Behavior"
+                }
               }
             ]
           },

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all_on_variant-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all_on_variant-4.snap
@@ -1,6 +1,6 @@
 ---
 source: reflectapi-demo/src/tests/serde.rs
-expression: "reflectapi::openapi::Spec::from(&schema)"
+expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
 ---
 {
   "openapi": "3.1.0",
@@ -57,17 +57,7 @@ expression: "reflectapi::openapi::Spec::from(&schema)"
             }
           },
           {
-            "type": "object",
-            "properties": {
-              "Variant2": {
-                "type": "array",
-                "prefixItems": [
-                  {
-                    "$ref": "#/components/schemas/u8"
-                  }
-                ]
-              }
-            }
+            "$ref": "#/components/schemas/u8"
           }
         ]
       },

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_variant_field-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_variant_field-4.snap
@@ -1,6 +1,6 @@
 ---
 source: reflectapi-demo/src/tests/serde.rs
-expression: "reflectapi::openapi::Spec::from(&schema)"
+expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
 ---
 {
   "openapi": "3.1.0",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag-4.snap
@@ -1,6 +1,6 @@
 ---
 source: reflectapi-demo/src/tests/serde.rs
-expression: "reflectapi::openapi::Spec::from(&schema)"
+expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
 ---
 {
   "openapi": "3.1.0",
@@ -55,15 +55,7 @@ expression: "reflectapi::openapi::Spec::from(&schema)"
             }
           },
           {
-            "type": "array",
-            "prefixItems": [
-              {
-                "$ref": "#/components/schemas/u8"
-              },
-              {
-                "$ref": "#/components/schemas/std.string.String"
-              }
-            ]
+            "$ref": "#/components/schemas/u8"
           }
         ],
         "discriminator": {

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content-4.snap
@@ -1,6 +1,6 @@
 ---
 source: reflectapi-demo/src/tests/serde.rs
-expression: "reflectapi::openapi::Spec::from(&schema)"
+expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
 ---
 {
   "openapi": "3.1.0",
@@ -60,20 +60,7 @@ expression: "reflectapi::openapi::Spec::from(&schema)"
             }
           },
           {
-            "type": "object",
-            "properties": {
-              "content": {
-                "type": "array",
-                "prefixItems": [
-                  {
-                    "$ref": "#/components/schemas/u8"
-                  }
-                ]
-              },
-              "type": {
-                "type": "string"
-              }
-            }
+            "$ref": "#/components/schemas/u8"
           }
         ]
       },

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content_rename_all-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content_rename_all-4.snap
@@ -1,6 +1,6 @@
 ---
 source: reflectapi-demo/src/tests/serde.rs
-expression: "reflectapi::openapi::Spec::from(&schema)"
+expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
 ---
 {
   "openapi": "3.1.0",
@@ -60,20 +60,7 @@ expression: "reflectapi::openapi::Spec::from(&schema)"
             }
           },
           {
-            "type": "object",
-            "properties": {
-              "content": {
-                "type": "array",
-                "prefixItems": [
-                  {
-                    "$ref": "#/components/schemas/u8"
-                  }
-                ]
-              },
-              "type": {
-                "type": "string"
-              }
-            }
+            "$ref": "#/components/schemas/u8"
           }
         ]
       },

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_untagged-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_untagged-4.snap
@@ -1,6 +1,6 @@
 ---
 source: reflectapi-demo/src/tests/serde.rs
-expression: "reflectapi::openapi::Spec::from(&schema)"
+expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
 ---
 {
   "openapi": "3.1.0",
@@ -44,12 +44,7 @@ expression: "reflectapi::openapi::Spec::from(&schema)"
       "reflectapi_demo.tests.serde.TestEnumUntagged": {
         "oneOf": [
           {
-            "type": "array",
-            "prefixItems": [
-              {
-                "$ref": "#/components/schemas/u8"
-              }
-            ]
+            "$ref": "#/components/schemas/u8"
           },
           {
             "type": "object",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_rename_to_invalid_chars-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_rename_to_invalid_chars-4.snap
@@ -1,6 +1,6 @@
 ---
 source: reflectapi-demo/src/tests/serde.rs
-expression: "reflectapi::openapi::Spec::from(&schema)"
+expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
 ---
 {
   "openapi": "3.1.0",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_untagged-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_untagged-4.snap
@@ -1,6 +1,6 @@
 ---
 source: reflectapi-demo/src/tests/serde.rs
-expression: "reflectapi::openapi::Spec::from(&schema)"
+expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
 ---
 {
   "openapi": "3.1.0",
@@ -44,17 +44,7 @@ expression: "reflectapi::openapi::Spec::from(&schema)"
       "reflectapi_demo.tests.serde.TestEnumWithVariantUntagged": {
         "oneOf": [
           {
-            "type": "object",
-            "properties": {
-              "Variant1": {
-                "type": "array",
-                "prefixItems": [
-                  {
-                    "$ref": "#/components/schemas/u8"
-                  }
-                ]
-              }
-            }
+            "$ref": "#/components/schemas/u8"
           }
         ]
       },

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__write_openapi_spec.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__write_openapi_spec.snap
@@ -364,13 +364,7 @@ expression: s
                 "properties": {}
               },
               {
-                "description": "The value is provided and set to some value",
-                "type": "array",
-                "prefixItems": [
-                  {
-                    "$ref": "#/components/schemas/u8"
-                  }
-                ]
+                "$ref": "#/components/schemas/u8"
               }
             ]
           },
@@ -387,17 +381,11 @@ expression: s
                 "properties": {}
               },
               {
-                "description": "The value is provided and set to some value",
+                "description": "Expandable array type",
                 "type": "array",
-                "prefixItems": [
-                  {
-                    "description": "Expandable array type",
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/myapi.model.Behavior"
-                    }
-                  }
-                ]
+                "items": {
+                  "$ref": "#/components/schemas/myapi.model.Behavior"
+                }
               }
             ]
           },

--- a/reflectapi/src/codegen/openapi.rs
+++ b/reflectapi/src/codegen/openapi.rs
@@ -480,6 +480,10 @@ impl Converter {
     ) -> InlineOrRef<Schema> {
         assert!(adt.parameters.is_empty(), "expect enum to be instantiated");
 
+        if variant.fields.len() == 1 && !variant.fields[0].is_named() {
+            return self.convert_type_ref(schema, kind, variant.fields[0].type_ref());
+        }
+
         let mut strukt = crate::Struct {
             name: variant.name().to_owned(),
             serde_name: variant.serde_name.to_owned(),


### PR DESCRIPTION
They would be represented as a single item tuple which is incorrect.