### PR TITLE
Move client error type from generic to associated type

### DIFF
--- a/reflectapi-demo/clients/typescript/generated.ts
+++ b/reflectapi-demo/clients/typescript/generated.ts
@@ -65,6 +65,8 @@ export interface Client {
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 
+export type FixedSizeArray<T, N extends number> = Array<T> & { length: N };
+
 export class Result<T, E> {
   constructor(private value: { ok: T } | { err: E }) {}
 

--- a/reflectapi-demo/src/tests/mod.rs
+++ b/reflectapi-demo/src/tests/mod.rs
@@ -15,7 +15,7 @@ fn write_schema() {
     let (schema, _) = crate::builder().build().unwrap();
 
     std::fs::write(
-        format!("{}/{}", env!("CARGO_MANIFEST_DIR"), "reflectapi.json"),
+        format!("{}/reflectapi.json", env!("CARGO_MANIFEST_DIR")),
         serde_json::to_string_pretty(&schema).unwrap(),
     )
     .unwrap();
@@ -28,10 +28,52 @@ fn write_openapi_spec() {
     let spec = reflectapi::codegen::openapi::Spec::from(&schema);
     let s = serde_json::to_string_pretty(&spec).unwrap();
 
-    std::fs::write(
-        format!("{}/{}", env!("CARGO_MANIFEST_DIR"), "openapi.json"),
-        &s,
+    std::fs::write(format!("{}/openapi.json", env!("CARGO_MANIFEST_DIR")), &s).unwrap();
+    insta::assert_snapshot!(s);
+}
+
+#[test]
+fn write_rust_client() {
+    let (schema, _) = crate::builder().build().unwrap();
+    let src = reflectapi::codegen::rust::generate(
+        schema,
+        &reflectapi::codegen::Config {
+            format: true,
+            typecheck: false,
+            shared_modules: vec![],
+        },
     )
     .unwrap();
-    insta::assert_snapshot!(s);
+
+    std::fs::write(
+        format!(
+            "{}/clients/rust/generated/src/generated.rs",
+            env!("CARGO_MANIFEST_DIR"),
+        ),
+        src,
+    )
+    .unwrap();
+}
+
+#[test]
+fn write_typescript_client() {
+    let (schema, _) = crate::builder().build().unwrap();
+    let src = reflectapi::codegen::typescript::generate(
+        schema,
+        &reflectapi::codegen::Config {
+            format: true,
+            typecheck: false,
+            shared_modules: vec![],
+        },
+    )
+    .unwrap();
+
+    std::fs::write(
+        format!(
+            "{}/clients/typescript/generated.ts",
+            env!("CARGO_MANIFEST_DIR"),
+        ),
+        src,
+    )
+    .unwrap();
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_enum_documented-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_enum_documented-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::basic::TestEnumDocumented<u8>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -122,15 +121,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_documented-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_documented-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::basic::TestStructDocumented,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -113,15 +112,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_empty-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_empty-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructEmpty,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -109,15 +108,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_newtype-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_newtype-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructNewtype,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -108,15 +107,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::basic::TestStructOneBasicFieldString,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -108,15 +107,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructOneBasicFieldStringReflectBoth,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -111,15 +110,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally-3.snap
@@ -16,34 +16,31 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
     pub async fn inout_test(&self, input: super::types::reflectapi_demo::tests::basic::TestStructOneBasicFieldStringReflectBothEqually, headers: reflectapi::Empty)
-        -> Result<super::types::reflectapi_demo::tests::basic::TestStructOneBasicFieldStringReflectBothEqually, super::Error<reflectapi::Empty, E>>{
+        -> Result<super::types::reflectapi_demo::tests::basic::TestStructOneBasicFieldStringReflectBothEqually, super::Error<reflectapi::Empty, C::Error>>{
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -64,13 +61,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -105,15 +104,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally2-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally2-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::basic::TestStructOneBasicFieldStringReflectBothEqually,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -108,15 +107,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_with_attributes-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_with_attributes-3.snap
@@ -16,34 +16,31 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
     pub async fn inout_test(&self, input: super::types::reflectapi_demo::tests::basic::input::TestStructOneBasicFieldStringReflectBothDifferently, headers: reflectapi::Empty)
-        -> Result<super::types::reflectapi_demo::tests::basic::output::TestStructOneBasicFieldStringReflectBothDifferently, super::Error<reflectapi::Empty, E>>{
+        -> Result<super::types::reflectapi_demo::tests::basic::output::TestStructOneBasicFieldStringReflectBothDifferently, super::Error<reflectapi::Empty, C::Error>>{
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -64,13 +61,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -114,15 +113,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_u32-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_u32-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::basic::TestStructOneBasicFieldU32,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -108,15 +107,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_option-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_option-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructOption,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -111,15 +110,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_tuple-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_tuple-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructTuple,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -109,15 +108,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_unit_type-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_unit_type-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructUnitType,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -109,15 +108,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_all_primitive_type_fields-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_all_primitive_type_fields-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithAllPrimitiveTypeFields,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -223,15 +222,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithArc,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -111,15 +110,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc_pointer_only-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc_pointer_only-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithArcPointerOnly,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -111,15 +110,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithAttributes,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -108,15 +107,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_input_only-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_input_only-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::output::TestStructWithAttributesInputOnly,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -117,15 +116,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_output_only-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_output_only-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::output::TestStructWithAttributesOutputOnly,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -117,15 +116,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_type_only-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_type_only-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithAttributesTypeOnly,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -108,15 +107,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_fixed_size_array-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_fixed_size_array-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithFixedSizeArray,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -111,15 +110,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashmap-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashmap-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithHashMap,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -111,15 +110,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithHashSetField,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -111,15 +110,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field_generic-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field_generic-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -40,20 +35,22 @@ pub mod interface {
             super::types::reflectapi_demo::tests::basic::TestStructWithHashSetFieldGeneric<
                 std::string::String,
             >,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -74,13 +71,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -115,15 +114,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithNested,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -116,15 +115,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested_external-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested_external-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithNestedExternal,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -118,15 +117,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_self_via_arc-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_self_via_arc-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithSelfViaArc,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -111,15 +110,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithSkipField,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -109,15 +108,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_input-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_input-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::output::TestStructWithSkipFieldInput,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -118,15 +117,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_output-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_output-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::output::TestStructWithSkipFieldOutput,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -118,15 +117,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_array-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_array-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithTransformArray,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -111,15 +110,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_both-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_both-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithTransformBoth,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -111,15 +110,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithTransformFallback,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -111,15 +110,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback_nested-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback_nested-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithTransformFallbackNested,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -111,15 +110,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_input-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_input-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::output::TestStructWithTransformInput,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -120,15 +119,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_output-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_output-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::output::TestStructWithTransformOutput,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -120,15 +119,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithTuple,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -111,15 +110,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple12-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple12-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithTuple12,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -124,15 +123,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithVec,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -111,15 +110,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_external-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_external-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithVecExternal,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -120,15 +119,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_nested-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_nested-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithVecNested,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -122,15 +121,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_two-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_two-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithVecTwo,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -112,15 +111,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnum,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -109,15 +108,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_empty-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_empty-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnumEmpty,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -106,15 +105,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_rename_num-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_rename_num-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::enums::Nums,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -113,15 +112,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_basic_variant_and_fields_and_named_fields-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_basic_variant_and_fields_and_named_fields-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnumWithBasicVariantAndFieldsAndNamedFields,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -113,15 +112,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_ignored_input-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_ignored_input-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnumWithDiscriminantIgnored,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -109,15 +108,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_ignored_output-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_ignored_output-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn output_test(
             &self,
@@ -36,7 +31,7 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::enums::TestEnumWithDiscriminantIgnored,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/output_test", input, headers)
                 .await
@@ -44,13 +39,15 @@ pub mod interface {
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -71,13 +68,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -113,15 +112,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_input-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_input-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnumWithDiscriminant,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -109,15 +108,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_output-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_output-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn output_test(
             &self,
@@ -36,7 +31,7 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::enums::TestEnumWithDiscriminant,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/output_test", input, headers)
                 .await
@@ -44,13 +39,15 @@ pub mod interface {
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -71,13 +68,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -113,15 +112,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_empty_variant_and_fields-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_empty_variant_and_fields-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnumWithEmptyVariantAndFields,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -109,15 +108,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_fields-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_fields-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnumWithFields,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -109,15 +108,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnumWithGenerics<u8>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -109,15 +108,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnumWithGenericsAndFields<u8>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -109,15 +108,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields_and_named_fields-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields_and_named_fields-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnumWithGenericsAndFieldsAndNamedFields<u8>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -110,15 +109,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithCircularReference,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -108,15 +107,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGeneric<u8>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -109,15 +108,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_parent-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_parent-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericParent<u8>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -115,15 +114,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBox<super::types::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBox<u8, u16>, super::types::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBox<std::string::String, u32>>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -109,15 +108,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBoxParent<super::types::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBoxParent<u8, u16>, super::types::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBoxParent<std::string::String, u32>>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -114,15 +113,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent_specific-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent_specific-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBoxParentSpecific,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -114,15 +113,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithNestedGenericStruct,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -113,15 +112,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct_twice-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct_twice-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithNestedGenericStructTwice,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -114,15 +113,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_simple_generic-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_simple_generic-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithSimpleGeneric<u8>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -108,15 +107,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithVecGeneric<u8>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -108,15 +107,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
@@ -36,19 +31,21 @@ pub mod interface {
                 u8,
             >,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -69,13 +66,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -115,15 +114,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic_generic-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic_generic-3.snap
@@ -16,37 +16,34 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn input_test(
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithVecGenericGenericGeneric<std::vec::Vec<u8>>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -67,13 +64,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -113,15 +112,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__namespace__namespace_with_dash-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__namespace__namespace_with_dash-3.snap
@@ -16,64 +16,55 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
-        pub jobs_two: JobsTwoInterface<E, C>,
+    pub struct Interface<C: super::Client + Clone> {
+        pub jobs_two: JobsTwoInterface<C>,
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self {
                 jobs_two: JobsTwoInterface::new(client.clone(), base_url.clone()),
                 client,
                 base_url,
-                marker: std::marker::PhantomData,
             }
         }
     }
 
     #[derive(Debug)]
-    pub struct JobsTwoInterface<E, C: super::Client<E> + Clone> {
-        pub pet_orders: JobsTwoPetOrdersInterface<E, C>,
+    pub struct JobsTwoInterface<C: super::Client + Clone> {
+        pub pet_orders: JobsTwoPetOrdersInterface<C>,
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> JobsTwoInterface<E, C> {
+    impl<C: super::Client + Clone> JobsTwoInterface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self {
                 pet_orders: JobsTwoPetOrdersInterface::new(client.clone(), base_url.clone()),
                 client,
                 base_url,
-                marker: std::marker::PhantomData,
             }
         }
     }
 
     #[derive(Debug)]
-    pub struct JobsTwoPetOrdersInterface<E, C: super::Client<E> + Clone> {
+    pub struct JobsTwoPetOrdersInterface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> JobsTwoPetOrdersInterface<E, C> {
+    impl<C: super::Client + Clone> JobsTwoPetOrdersInterface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         /// desc
         pub async fn list_x(
             &self,
             input: reflectapi::Empty,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, E>> {
+        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
             super::__request_impl(
                 &self.client,
                 &self.base_url,
@@ -86,13 +77,15 @@ pub mod interface {
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -113,13 +106,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -139,15 +134,15 @@ impl Client<reqwest::Error> for reqwest::Client {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::MyEnum,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -112,15 +111,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumRenameAll,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -112,15 +111,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all_on_variant-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all_on_variant-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumRenameAllOnVariant,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -115,15 +114,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_variant_field-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_variant_field-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumRenameVariantField,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -112,15 +111,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumTag,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -113,15 +112,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumTagContent,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -113,15 +112,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content_rename_all-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content_rename_all-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumTagContentRenameAll,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -115,15 +114,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_untagged-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_untagged-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumUntagged,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -113,15 +112,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_field_skip-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_field_skip-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumWithFieldSkip,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -111,15 +110,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_rename_to_invalid_chars-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_rename_to_invalid_chars-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumWithRenameToInvalidChars,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -115,15 +114,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_other-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_other-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestEnumWithVariantOther,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -123,15 +122,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumWithVariantSkip,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -109,15 +108,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_deserialize-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_deserialize-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestEnumWithVariantSkipDeserialize,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -119,15 +118,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_serialize-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_serialize-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestEnumWithVariantSkipSerialize,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -118,15 +117,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_untagged-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_untagged-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumWithVariantUntagged,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -112,15 +111,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_from-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_from-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestStructFromProxy,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -123,15 +122,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_into-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_into-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestStructIntoProxy,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -123,15 +122,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::MyStruct,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -109,15 +108,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestStructRenameAll,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -112,15 +111,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_differently-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_differently-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestStructRenameAllDifferently,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -121,15 +120,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_pascal_case-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_pascal_case-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestStructRenameAllPascalCase,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -112,15 +111,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_differently-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_differently-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::MyStructOutput,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -112,15 +111,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_field-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_field-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestStructRenameField,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -121,15 +120,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_try_from-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_try_from-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestStructTryFormProxy,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -122,15 +121,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestStructWithFlatten,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -117,15 +116,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestStructWithFlattenOptional,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -117,15 +116,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional_and_required-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional_and_required-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestStructWithFlattenOptionalAndRequired,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -125,15 +124,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_invalid_chars-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_invalid_chars-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestStructWithRenameToInvalidChars,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -112,15 +111,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_kebab_case-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_kebab_case-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::struct_name,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -112,15 +111,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_default-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_default-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestStructWithSerdeDefault,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -121,15 +120,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestStructWithSerdeSkip,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -109,15 +108,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_deserialize-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_deserialize-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestStructWithSerdeSkipDeserialize,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -118,15 +117,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestStructWithSerdeSkipSerialize,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -118,15 +117,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize_if-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize_if-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestStructWithSerdeSkipSerializeIf,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -121,15 +120,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_transparent-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_transparent-3.snap
@@ -16,19 +16,14 @@ pub use interface::Interface;
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<E, C: super::Client<E> + Clone> {
+    pub struct Interface<C: super::Client + Clone> {
         client: C,
         base_url: std::string::String,
-        marker: std::marker::PhantomData<E>,
     }
 
-    impl<E, C: super::Client<E> + Clone> Interface<E, C> {
+    impl<C: super::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
-            Self {
-                client,
-                base_url,
-                marker: std::marker::PhantomData,
-            }
+            Self { client, base_url }
         }
         pub async fn inout_test(
             &self,
@@ -36,20 +31,22 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestStructWithSerdeTransparent,
-            super::Error<reflectapi::Empty, E>,
+            super::Error<reflectapi::Empty, C::Error>,
         > {
             super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
         }
     }
 }
 
-pub trait Client<E> {
+pub trait Client {
+    type Error;
+
     fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), E>>;
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
 }
 
 pub enum Error<AE, NE> {
@@ -70,13 +67,15 @@ pub enum ProtocolErrorStage {
 }
 
 #[cfg(feature = "reqwest")]
-impl Client<reqwest::Error> for reqwest::Client {
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
     async fn request(
         &self,
         path: &str,
         body: bytes::Bytes,
         headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), reqwest::Error> {
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
         let mut request = self.post(path);
         for (k, v) in headers {
             request = request.header(k, v);
@@ -108,15 +107,15 @@ pub mod types {
     }
 }
 
-async fn __request_impl<C, NE, I, H, O, E>(
+async fn __request_impl<C, I, H, O, E>(
     client: &C,
     base_url: &str,
     path: &str,
     body: I,
     headers: H,
-) -> Result<O, Error<E, NE>>
+) -> Result<O, Error<E, C::Error>>
 where
-    C: Client<NE>,
+    C: Client,
     I: serde::Serialize,
     H: serde::Serialize,
     O: serde::de::DeserializeOwned,


### PR DESCRIPTION
`Error` as an associated type is the correct place to put this parameter. A type will never need to implement the `Client` trait over more than one error type. 

This cleans up the code a decent amount (less generics and phantom data) and will reduce any potential type inference issues.
