### PR TITLE
codegen preserve namespaces and generics

### DIFF
--- a/reflectapi-demo/openapi.json
+++ b/reflectapi-demo/openapi.json
@@ -127,7 +127,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "title": "myapi.proto.Paginated",
+                  "title": "myapi.proto.Paginated<myapi.model.Pet>",
                   "required": [
                     "items"
                   ],

--- a/reflectapi-demo/openapi.json
+++ b/reflectapi-demo/openapi.json
@@ -36,7 +36,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PetsCreateRequest"
+                "$ref": "#/components/schemas/myapi.proto.PetsCreateRequest"
               }
             }
           },
@@ -62,7 +62,7 @@
             "in": "header",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/String"
+              "$ref": "#/components/schemas/std.string.String"
             }
           }
         ]
@@ -85,7 +85,7 @@
                       "type": "null"
                     },
                     {
-                      "$ref": "#/components/schemas/Pet"
+                      "$ref": "#/components/schemas/myapi.model.Pet"
                     }
                   ]
                 }
@@ -99,7 +99,7 @@
             "in": "header",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/String"
+              "$ref": "#/components/schemas/std.string.String"
             }
           }
         ]
@@ -114,7 +114,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PetsListRequest"
+                "$ref": "#/components/schemas/myapi.proto.PetsListRequest"
               }
             }
           },
@@ -127,7 +127,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "title": "Paginated",
+                  "title": "myapi.proto.Paginated",
                   "required": [
                     "items"
                   ],
@@ -139,7 +139,7 @@
                           "type": "null"
                         },
                         {
-                          "$ref": "#/components/schemas/String"
+                          "$ref": "#/components/schemas/std.string.String"
                         }
                       ]
                     },
@@ -147,7 +147,7 @@
                       "description": "Expandable array type",
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/Pet"
+                        "$ref": "#/components/schemas/myapi.model.Pet"
                       }
                     }
                   }
@@ -162,7 +162,7 @@
             "in": "header",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/String"
+              "$ref": "#/components/schemas/std.string.String"
             }
           }
         ]
@@ -177,7 +177,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PetsRemoveRequest"
+                "$ref": "#/components/schemas/myapi.proto.PetsRemoveRequest"
               }
             }
           },
@@ -203,7 +203,7 @@
             "in": "header",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/String"
+              "$ref": "#/components/schemas/std.string.String"
             }
           }
         ]
@@ -218,7 +218,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PetsUpdateRequest"
+                "$ref": "#/components/schemas/myapi.proto.PetsUpdateRequest"
               }
             }
           },
@@ -244,7 +244,7 @@
             "in": "header",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/String"
+              "$ref": "#/components/schemas/std.string.String"
             }
           }
         ]
@@ -253,7 +253,11 @@
   },
   "components": {
     "schemas": {
-      "Behavior": {
+      "f64": {
+        "description": "64-bit floating point number",
+        "type": "number"
+      },
+      "myapi.model.Behavior": {
         "oneOf": [
           {
             "type": "string"
@@ -272,7 +276,7 @@
                     "$ref": "#/components/schemas/f64"
                   },
                   {
-                    "$ref": "#/components/schemas/String"
+                    "$ref": "#/components/schemas/std.string.String"
                   }
                 ]
               }
@@ -293,10 +297,10 @@
                 ],
                 "properties": {
                   "description": {
-                    "$ref": "#/components/schemas/String"
+                    "$ref": "#/components/schemas/std.string.String"
                   },
                   "notes": {
-                    "$ref": "#/components/schemas/String"
+                    "$ref": "#/components/schemas/std.string.String"
                   }
                 }
               }
@@ -304,7 +308,7 @@
           }
         ]
       },
-      "Kind": {
+      "myapi.model.Kind": {
         "oneOf": [
           {
             "description": " A dog",
@@ -316,9 +320,9 @@
           }
         ]
       },
-      "Pet": {
+      "myapi.model.Pet": {
         "type": "object",
-        "title": "Pet",
+        "title": "myapi.model.Pet",
         "required": [
           "name",
           "kind"
@@ -339,28 +343,28 @@
             "description": "Expandable array type",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Behavior"
+              "$ref": "#/components/schemas/myapi.model.Behavior"
             }
           },
           "kind": {
-            "$ref": "#/components/schemas/Kind"
+            "$ref": "#/components/schemas/myapi.model.Kind"
           },
           "name": {
-            "$ref": "#/components/schemas/String"
+            "$ref": "#/components/schemas/std.string.String"
           }
         }
       },
-      "PetsCreateRequest": {
+      "myapi.proto.PetsCreateRequest": {
         "type": "array",
         "prefixItems": [
           {
-            "$ref": "#/components/schemas/Pet"
+            "$ref": "#/components/schemas/myapi.model.Pet"
           }
         ]
       },
-      "PetsListRequest": {
+      "myapi.proto.PetsListRequest": {
         "type": "object",
-        "title": "PetsListRequest",
+        "title": "myapi.proto.PetsListRequest",
         "properties": {
           "cursor": {
             "oneOf": [
@@ -369,7 +373,7 @@
                 "type": "null"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               }
             ]
           },
@@ -386,21 +390,21 @@
           }
         }
       },
-      "PetsRemoveRequest": {
+      "myapi.proto.PetsRemoveRequest": {
         "type": "object",
-        "title": "PetsRemoveRequest",
+        "title": "myapi.proto.PetsRemoveRequest",
         "required": [
           "name"
         ],
         "properties": {
           "name": {
-            "$ref": "#/components/schemas/String"
+            "$ref": "#/components/schemas/std.string.String"
           }
         }
       },
-      "PetsUpdateRequest": {
+      "myapi.proto.PetsUpdateRequest": {
         "type": "object",
-        "title": "PetsUpdateRequest",
+        "title": "myapi.proto.PetsUpdateRequest",
         "required": [
           "name"
         ],
@@ -426,7 +430,7 @@
                 "description": "Expandable array type",
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/Behavior"
+                  "$ref": "#/components/schemas/myapi.model.Behavior"
                 }
               }
             ]
@@ -438,22 +442,18 @@
                 "type": "null"
               },
               {
-                "$ref": "#/components/schemas/Kind"
+                "$ref": "#/components/schemas/myapi.model.Kind"
               }
             ]
           },
           "name": {
-            "$ref": "#/components/schemas/String"
+            "$ref": "#/components/schemas/std.string.String"
           }
         }
       },
-      "String": {
+      "std.string.String": {
         "description": "UTF-8 encoded string",
         "type": "string"
-      },
-      "f64": {
-        "description": "64-bit floating point number",
-        "type": "number"
       },
       "u8": {
         "description": "8-bit unsigned integer",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_empty-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_empty-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructEmpty"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructEmpty"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructEmpty"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructEmpty"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructEmpty": {
+      "reflectapi_demo.tests.basic.TestStructEmpty": {
         "type": "object",
-        "title": "TestStructEmpty",
+        "title": "reflectapi_demo.tests.basic.TestStructEmpty",
         "properties": {}
       }
     }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_newtype-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_newtype-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructNewtype"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructNewtype"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructNewtype"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructNewtype"
                 }
               }
             }
@@ -41,17 +41,17 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "String": {
-        "description": "UTF-8 encoded string",
-        "type": "string"
-      },
-      "TestStructNewtype": {
+      "reflectapi_demo.tests.basic.TestStructNewtype": {
         "type": "array",
         "prefixItems": [
           {
-            "$ref": "#/components/schemas/String"
+            "$ref": "#/components/schemas/std.string.String"
           }
         ]
+      },
+      "std.string.String": {
+        "description": "UTF-8 encoded string",
+        "type": "string"
       }
     }
   }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructOneBasicFieldStringReflectBoth"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructOneBasicFieldStringReflectBoth"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructOneBasicFieldStringReflectBoth"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructOneBasicFieldStringReflectBoth"
                 }
               }
             }
@@ -41,21 +41,21 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "String": {
-        "description": "UTF-8 encoded string",
-        "type": "string"
-      },
-      "TestStructOneBasicFieldStringReflectBoth": {
+      "reflectapi_demo.tests.basic.TestStructOneBasicFieldStringReflectBoth": {
         "type": "object",
-        "title": "TestStructOneBasicFieldStringReflectBoth",
+        "title": "reflectapi_demo.tests.basic.TestStructOneBasicFieldStringReflectBoth",
         "required": [
           "_f"
         ],
         "properties": {
           "_f": {
-            "$ref": "#/components/schemas/String"
+            "$ref": "#/components/schemas/std.string.String"
           }
         }
+      },
+      "std.string.String": {
+        "description": "UTF-8 encoded string",
+        "type": "string"
       }
     }
   }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructOneBasicFieldStringReflectBothEqually"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructOneBasicFieldStringReflectBothEqually"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructOneBasicFieldStringReflectBothEqually"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructOneBasicFieldStringReflectBothEqually"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructOneBasicFieldStringReflectBothEqually": {
+      "reflectapi_demo.tests.basic.TestStructOneBasicFieldStringReflectBothEqually": {
         "type": "object",
-        "title": "TestStructOneBasicFieldStringReflectBothEqually",
+        "title": "reflectapi_demo.tests.basic.TestStructOneBasicFieldStringReflectBothEqually",
         "required": [
           "_f"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_with_attributes-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_with_attributes-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructOneBasicFieldStringReflectBothDifferently"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructOneBasicFieldStringReflectBothDifferently"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructOneBasicFieldStringReflectBothDifferently"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructOneBasicFieldStringReflectBothDifferently"
                 }
               }
             }
@@ -41,9 +41,13 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructOneBasicFieldStringReflectBothDifferently": {
+      "i32": {
+        "description": "32-bit signed integer",
+        "type": "integer"
+      },
+      "reflectapi_demo.tests.basic.TestStructOneBasicFieldStringReflectBothDifferently": {
         "type": "object",
-        "title": "TestStructOneBasicFieldStringReflectBothDifferently",
+        "title": "reflectapi_demo.tests.basic.TestStructOneBasicFieldStringReflectBothDifferently",
         "required": [
           "_f"
         ],
@@ -52,10 +56,6 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "$ref": "#/components/schemas/i32"
           }
         }
-      },
-      "i32": {
-        "description": "32-bit signed integer",
-        "type": "integer"
       }
     }
   }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_option-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_option-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructOption"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructOption"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructOption"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructOption"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructOption": {
+      "reflectapi_demo.tests.basic.TestStructOption": {
         "type": "object",
-        "title": "TestStructOption",
+        "title": "reflectapi_demo.tests.basic.TestStructOption",
         "required": [
           "_f"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_tuple-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_tuple-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructTuple"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructTuple"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructTuple"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructTuple"
                 }
               }
             }
@@ -41,20 +41,20 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "String": {
-        "description": "UTF-8 encoded string",
-        "type": "string"
-      },
-      "TestStructTuple": {
+      "reflectapi_demo.tests.basic.TestStructTuple": {
         "type": "array",
         "prefixItems": [
           {
             "$ref": "#/components/schemas/u8"
           },
           {
-            "$ref": "#/components/schemas/String"
+            "$ref": "#/components/schemas/std.string.String"
           }
         ]
+      },
+      "std.string.String": {
+        "description": "UTF-8 encoded string",
+        "type": "string"
       },
       "u8": {
         "description": "8-bit unsigned integer",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_unit_type-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_unit_type-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructUnitType"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructUnitType"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructUnitType"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructUnitType"
                 }
               }
             }
@@ -41,15 +41,15 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructUnitType": {
+      "reflectapi_demo.tests.basic.TestStructUnitType": {
         "type": "array",
         "prefixItems": [
           {
-            "$ref": "#/components/schemas/Tuple0"
+            "$ref": "#/components/schemas/std.tuple.Tuple0"
           }
         ]
       },
-      "Tuple0": {
+      "std.tuple.Tuple0": {
         "description": "Unit type",
         "type": "null"
       }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_all_primitive_type_fields-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_all_primitive_type_fields-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithAllPrimitiveTypeFields"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithAllPrimitiveTypeFields"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithAllPrimitiveTypeFields"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithAllPrimitiveTypeFields"
                 }
               }
             }
@@ -41,19 +41,55 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "Infallible": {
-        "description": "Error object which is expected to be never returned",
-        "type": "object",
-        "title": "Infallible",
-        "properties": {}
+      "bool": {
+        "description": "Boolean value",
+        "type": "boolean"
       },
-      "String": {
-        "description": "UTF-8 encoded string",
+      "char": {
+        "description": "Unicode character",
         "type": "string"
       },
-      "TestStructWithAllPrimitiveTypeFields": {
+      "f32": {
+        "description": "32-bit floating point number",
+        "type": "number"
+      },
+      "f64": {
+        "description": "64-bit floating point number",
+        "type": "number"
+      },
+      "i128": {
+        "description": "128-bit signed integer",
+        "type": "integer"
+      },
+      "i16": {
+        "description": "16-bit signed integer",
+        "type": "integer"
+      },
+      "i32": {
+        "description": "32-bit signed integer",
+        "type": "integer"
+      },
+      "i64": {
+        "description": "64-bit signed integer",
+        "type": "integer"
+      },
+      "i8": {
+        "description": "8-bit signed integer",
+        "type": "integer"
+      },
+      "isize": {
+        "description": "Machine-specific-bit signed integer",
+        "type": "integer"
+      },
+      "reflectapi.Infallible": {
+        "description": "Error object which is expected to be never returned",
         "type": "object",
-        "title": "TestStructWithAllPrimitiveTypeFields",
+        "title": "reflectapi.Infallible",
+        "properties": {}
+      },
+      "reflectapi_demo.tests.basic.TestStructWithAllPrimitiveTypeFields": {
+        "type": "object",
+        "title": "reflectapi_demo.tests.basic.TestStructWithAllPrimitiveTypeFields",
         "required": [
           "_f_u8",
           "_f_u16",
@@ -123,7 +159,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "description": "Key-value map type",
             "type": "object",
             "additionalProperties": {
-              "$ref": "#/components/schemas/String"
+              "$ref": "#/components/schemas/std.string.String"
             }
           },
           "_f_hashset": {
@@ -150,7 +186,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "$ref": "#/components/schemas/i8"
           },
           "_f_infallible": {
-            "$ref": "#/components/schemas/Infallible"
+            "$ref": "#/components/schemas/reflectapi.Infallible"
           },
           "_f_isize": {
             "$ref": "#/components/schemas/isize"
@@ -192,7 +228,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "$ref": "#/components/schemas/u8"
           },
           "_f_str": {
-            "$ref": "#/components/schemas/String"
+            "$ref": "#/components/schemas/std.string.String"
           },
           "_f_tuple": {
             "description": "Tuple holding 2 elements",
@@ -202,7 +238,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               }
             ]
           },
@@ -214,31 +250,31 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               }
             ]
           },
@@ -250,31 +286,31 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
@@ -289,37 +325,37 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               }
             ]
           },
@@ -331,7 +367,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
@@ -346,13 +382,13 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               }
             ]
           },
@@ -364,13 +400,13 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
@@ -385,19 +421,19 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               }
             ]
           },
@@ -409,19 +445,19 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
@@ -436,25 +472,25 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               }
             ]
           },
@@ -466,25 +502,25 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
@@ -507,7 +543,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "$ref": "#/components/schemas/u8"
           },
           "_f_unit": {
-            "$ref": "#/components/schemas/Tuple0"
+            "$ref": "#/components/schemas/std.tuple.Tuple0"
           },
           "_f_usize": {
             "$ref": "#/components/schemas/usize"
@@ -521,49 +557,13 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           }
         }
       },
-      "Tuple0": {
-        "description": "Unit type",
-        "type": "null"
-      },
-      "bool": {
-        "description": "Boolean value",
-        "type": "boolean"
-      },
-      "char": {
-        "description": "Unicode character",
+      "std.string.String": {
+        "description": "UTF-8 encoded string",
         "type": "string"
       },
-      "f32": {
-        "description": "32-bit floating point number",
-        "type": "number"
-      },
-      "f64": {
-        "description": "64-bit floating point number",
-        "type": "number"
-      },
-      "i128": {
-        "description": "128-bit signed integer",
-        "type": "integer"
-      },
-      "i16": {
-        "description": "16-bit signed integer",
-        "type": "integer"
-      },
-      "i32": {
-        "description": "32-bit signed integer",
-        "type": "integer"
-      },
-      "i64": {
-        "description": "64-bit signed integer",
-        "type": "integer"
-      },
-      "i8": {
-        "description": "8-bit signed integer",
-        "type": "integer"
-      },
-      "isize": {
-        "description": "Machine-specific-bit signed integer",
-        "type": "integer"
+      "std.tuple.Tuple0": {
+        "description": "Unit type",
+        "type": "null"
       },
       "u128": {
         "description": "128-bit unsigned integer",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithArc"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithArc"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithArc"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithArc"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithArc": {
+      "reflectapi_demo.tests.basic.TestStructWithArc": {
         "type": "object",
-        "title": "TestStructWithArc",
+        "title": "reflectapi_demo.tests.basic.TestStructWithArc",
         "required": [
           "_f"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc_pointer_only-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc_pointer_only-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithArcPointerOnly"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithArcPointerOnly"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithArcPointerOnly"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithArcPointerOnly"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithArcPointerOnly": {
+      "reflectapi_demo.tests.basic.TestStructWithArcPointerOnly": {
         "type": "object",
-        "title": "TestStructWithArcPointerOnly",
+        "title": "reflectapi_demo.tests.basic.TestStructWithArcPointerOnly",
         "required": [
           "_f_pointer_arc"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_input_only-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_input_only-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithAttributesInputOnly"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithAttributesInputOnly"
                 }
               }
             }
@@ -41,21 +41,21 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "String": {
-        "description": "UTF-8 encoded string",
-        "type": "string"
-      },
-      "TestStructWithAttributesInputOnly": {
+      "reflectapi_demo.tests.basic.TestStructWithAttributesInputOnly": {
         "type": "object",
-        "title": "TestStructWithAttributesInputOnly",
+        "title": "reflectapi_demo.tests.basic.TestStructWithAttributesInputOnly",
         "required": [
           "_f"
         ],
         "properties": {
           "_f": {
-            "$ref": "#/components/schemas/String"
+            "$ref": "#/components/schemas/std.string.String"
           }
         }
+      },
+      "std.string.String": {
+        "description": "UTF-8 encoded string",
+        "type": "string"
       }
     }
   }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_output_only-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_output_only-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithAttributesOutputOnly"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithAttributesOutputOnly"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithAttributesOutputOnly"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithAttributesOutputOnly"
                 }
               }
             }
@@ -41,21 +41,21 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "String": {
-        "description": "UTF-8 encoded string",
-        "type": "string"
-      },
-      "TestStructWithAttributesOutputOnly": {
+      "reflectapi_demo.tests.basic.TestStructWithAttributesOutputOnly": {
         "type": "object",
-        "title": "TestStructWithAttributesOutputOnly",
+        "title": "reflectapi_demo.tests.basic.TestStructWithAttributesOutputOnly",
         "required": [
           "_f"
         ],
         "properties": {
           "_f": {
-            "$ref": "#/components/schemas/String"
+            "$ref": "#/components/schemas/std.string.String"
           }
         }
+      },
+      "std.string.String": {
+        "description": "UTF-8 encoded string",
+        "type": "string"
       }
     }
   }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_type_only-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_type_only-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/String"
+                  "$ref": "#/components/schemas/std.string.String"
                 }
               }
             }
@@ -41,7 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "String": {
+      "std.string.String": {
         "description": "UTF-8 encoded string",
         "type": "string"
       }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_fixed_size_array-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_fixed_size_array-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithFixedSizeArray"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithFixedSizeArray"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithFixedSizeArray"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithFixedSizeArray"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithFixedSizeArray": {
+      "reflectapi_demo.tests.basic.TestStructWithFixedSizeArray": {
         "type": "object",
-        "title": "TestStructWithFixedSizeArray",
+        "title": "reflectapi_demo.tests.basic.TestStructWithFixedSizeArray",
         "required": [
           "_f"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashmap-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashmap-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithHashMap"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithHashMap"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithHashMap"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithHashMap"
                 }
               }
             }
@@ -41,13 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "String": {
-        "description": "UTF-8 encoded string",
-        "type": "string"
-      },
-      "TestStructWithHashMap": {
+      "reflectapi_demo.tests.basic.TestStructWithHashMap": {
         "type": "object",
-        "title": "TestStructWithHashMap",
+        "title": "reflectapi_demo.tests.basic.TestStructWithHashMap",
         "required": [
           "_f"
         ],
@@ -56,10 +52,14 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "description": "Key-value map type",
             "type": "object",
             "additionalProperties": {
-              "$ref": "#/components/schemas/String"
+              "$ref": "#/components/schemas/std.string.String"
             }
           }
         }
+      },
+      "std.string.String": {
+        "description": "UTF-8 encoded string",
+        "type": "string"
       }
     }
   }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithHashSetField"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithHashSetField"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithHashSetField"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithHashSetField"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithHashSetField": {
+      "reflectapi_demo.tests.basic.TestStructWithHashSetField": {
         "type": "object",
-        "title": "TestStructWithHashSetField",
+        "title": "reflectapi_demo.tests.basic.TestStructWithHashSetField",
         "required": [
           "_f_hashset"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field_generic-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field_generic-4.snap
@@ -19,7 +19,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "application/json": {
               "schema": {
                 "type": "object",
-                "title": "TestStructWithHashSetFieldGeneric",
+                "title": "reflectapi_demo.tests.basic.TestStructWithHashSetFieldGeneric",
                 "required": [
                   "_f_hashset"
                 ],
@@ -28,7 +28,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
                     "description": "Value set type",
                     "type": "array",
                     "items": {
-                      "$ref": "#/components/schemas/String"
+                      "$ref": "#/components/schemas/std.string.String"
                     },
                     "uniqueItems": true
                   }
@@ -45,7 +45,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "title": "TestStructWithHashSetFieldGeneric",
+                  "title": "reflectapi_demo.tests.basic.TestStructWithHashSetFieldGeneric",
                   "required": [
                     "_f_hashset"
                   ],
@@ -54,7 +54,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
                       "description": "Value set type",
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/String"
+                        "$ref": "#/components/schemas/std.string.String"
                       },
                       "uniqueItems": true
                     }
@@ -69,7 +69,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "String": {
+      "std.string.String": {
         "description": "UTF-8 encoded string",
         "type": "string"
       }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field_generic-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field_generic-4.snap
@@ -19,7 +19,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "application/json": {
               "schema": {
                 "type": "object",
-                "title": "reflectapi_demo.tests.basic.TestStructWithHashSetFieldGeneric",
+                "title": "reflectapi_demo.tests.basic.TestStructWithHashSetFieldGeneric<std.string.String>",
                 "required": [
                   "_f_hashset"
                 ],
@@ -45,7 +45,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "title": "reflectapi_demo.tests.basic.TestStructWithHashSetFieldGeneric",
+                  "title": "reflectapi_demo.tests.basic.TestStructWithHashSetFieldGeneric<std.string.String>",
                   "required": [
                     "_f_hashset"
                   ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithNested"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithNested"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithNested"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithNested"
                 }
               }
             }
@@ -41,33 +41,33 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "String": {
+      "reflectapi_demo.tests.basic.TestStructNested": {
+        "type": "object",
+        "title": "reflectapi_demo.tests.basic.TestStructNested",
+        "required": [
+          "_f"
+        ],
+        "properties": {
+          "_f": {
+            "$ref": "#/components/schemas/std.string.String"
+          }
+        }
+      },
+      "reflectapi_demo.tests.basic.TestStructWithNested": {
+        "type": "object",
+        "title": "reflectapi_demo.tests.basic.TestStructWithNested",
+        "required": [
+          "_f"
+        ],
+        "properties": {
+          "_f": {
+            "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructNested"
+          }
+        }
+      },
+      "std.string.String": {
         "description": "UTF-8 encoded string",
         "type": "string"
-      },
-      "TestStructNested": {
-        "type": "object",
-        "title": "TestStructNested",
-        "required": [
-          "_f"
-        ],
-        "properties": {
-          "_f": {
-            "$ref": "#/components/schemas/String"
-          }
-        }
-      },
-      "TestStructWithNested": {
-        "type": "object",
-        "title": "TestStructWithNested",
-        "required": [
-          "_f"
-        ],
-        "properties": {
-          "_f": {
-            "$ref": "#/components/schemas/TestStructNested"
-          }
-        }
       }
     }
   }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested_external-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested_external-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithNestedExternal"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithNestedExternal"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithNestedExternal"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithNestedExternal"
                 }
               }
             }
@@ -41,33 +41,33 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "String": {
+      "reflectapi_demo.tests.basic.TestStructWithNestedExternal": {
+        "type": "object",
+        "title": "reflectapi_demo.tests.basic.TestStructWithNestedExternal",
+        "required": [
+          "_f"
+        ],
+        "properties": {
+          "_f": {
+            "$ref": "#/components/schemas/reflectapi_demo.tests.test_lib.TestStructNested"
+          }
+        }
+      },
+      "reflectapi_demo.tests.test_lib.TestStructNested": {
+        "type": "object",
+        "title": "reflectapi_demo.tests.test_lib.TestStructNested",
+        "required": [
+          "_f"
+        ],
+        "properties": {
+          "_f": {
+            "$ref": "#/components/schemas/std.string.String"
+          }
+        }
+      },
+      "std.string.String": {
         "description": "UTF-8 encoded string",
         "type": "string"
-      },
-      "TestStructNested": {
-        "type": "object",
-        "title": "TestStructNested",
-        "required": [
-          "_f"
-        ],
-        "properties": {
-          "_f": {
-            "$ref": "#/components/schemas/String"
-          }
-        }
-      },
-      "TestStructWithNestedExternal": {
-        "type": "object",
-        "title": "TestStructWithNestedExternal",
-        "required": [
-          "_f"
-        ],
-        "properties": {
-          "_f": {
-            "$ref": "#/components/schemas/TestStructNested"
-          }
-        }
       }
     }
   }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_self_via_arc-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_self_via_arc-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithSelfViaArc"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithSelfViaArc"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithSelfViaArc"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithSelfViaArc"
                 }
               }
             }
@@ -41,15 +41,15 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithSelfViaArc": {
+      "reflectapi_demo.tests.basic.TestStructWithSelfViaArc": {
         "type": "object",
-        "title": "TestStructWithSelfViaArc",
+        "title": "reflectapi_demo.tests.basic.TestStructWithSelfViaArc",
         "required": [
           "_f"
         ],
         "properties": {
           "_f": {
-            "$ref": "#/components/schemas/TestStructWithSelfViaArc"
+            "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithSelfViaArc"
           }
         }
       }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithSkipField"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithSkipField"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithSkipField"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithSkipField"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithSkipField": {
+      "reflectapi_demo.tests.basic.TestStructWithSkipField": {
         "type": "object",
-        "title": "TestStructWithSkipField",
+        "title": "reflectapi_demo.tests.basic.TestStructWithSkipField",
         "properties": {}
       }
     }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_input-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_input-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithSkipFieldInput"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithSkipFieldInput"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithSkipFieldInput"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithSkipFieldInput"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithSkipFieldInput": {
+      "reflectapi_demo.tests.basic.TestStructWithSkipFieldInput": {
         "type": "object",
-        "title": "TestStructWithSkipFieldInput",
+        "title": "reflectapi_demo.tests.basic.TestStructWithSkipFieldInput",
         "properties": {}
       }
     }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_output-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_output-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithSkipFieldOutput"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithSkipFieldOutput"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithSkipFieldOutput"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithSkipFieldOutput"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithSkipFieldOutput": {
+      "reflectapi_demo.tests.basic.TestStructWithSkipFieldOutput": {
         "type": "object",
-        "title": "TestStructWithSkipFieldOutput",
+        "title": "reflectapi_demo.tests.basic.TestStructWithSkipFieldOutput",
         "required": [
           "_f"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_array-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_array-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithTransformArray"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithTransformArray"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithTransformArray"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithTransformArray"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithTransformArray": {
+      "reflectapi_demo.tests.basic.TestStructWithTransformArray": {
         "type": "object",
-        "title": "TestStructWithTransformArray",
+        "title": "reflectapi_demo.tests.basic.TestStructWithTransformArray",
         "required": [
           "_f"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_both-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_both-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithTransformBoth"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithTransformBoth"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithTransformBoth"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithTransformBoth"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithTransformBoth": {
+      "reflectapi_demo.tests.basic.TestStructWithTransformBoth": {
         "type": "object",
-        "title": "TestStructWithTransformBoth",
+        "title": "reflectapi_demo.tests.basic.TestStructWithTransformBoth",
         "required": [
           "_f"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithTransformFallback"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithTransformFallback"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithTransformFallback"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithTransformFallback"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithTransformFallback": {
+      "reflectapi_demo.tests.basic.TestStructWithTransformFallback": {
         "type": "object",
-        "title": "TestStructWithTransformFallback",
+        "title": "reflectapi_demo.tests.basic.TestStructWithTransformFallback",
         "required": [
           "_f"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback_nested-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback_nested-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithTransformFallbackNested"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithTransformFallbackNested"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithTransformFallbackNested"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithTransformFallbackNested"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithTransformFallbackNested": {
+      "reflectapi_demo.tests.basic.TestStructWithTransformFallbackNested": {
         "type": "object",
-        "title": "TestStructWithTransformFallbackNested",
+        "title": "reflectapi_demo.tests.basic.TestStructWithTransformFallbackNested",
         "required": [
           "_f"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_input-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_input-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithTransformInput"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithTransformInput"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithTransformInput"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithTransformInput"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithTransformInput": {
+      "reflectapi_demo.tests.basic.TestStructWithTransformInput": {
         "type": "object",
-        "title": "TestStructWithTransformInput",
+        "title": "reflectapi_demo.tests.basic.TestStructWithTransformInput",
         "required": [
           "_f"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_output-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_output-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithTransformOutput"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithTransformOutput"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithTransformOutput"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithTransformOutput"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithTransformOutput": {
+      "reflectapi_demo.tests.basic.TestStructWithTransformOutput": {
         "type": "object",
-        "title": "TestStructWithTransformOutput",
+        "title": "reflectapi_demo.tests.basic.TestStructWithTransformOutput",
         "required": [
           "_f"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithTuple"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithTuple"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithTuple"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithTuple"
                 }
               }
             }
@@ -41,13 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "String": {
-        "description": "UTF-8 encoded string",
-        "type": "string"
-      },
-      "TestStructWithTuple": {
+      "reflectapi_demo.tests.basic.TestStructWithTuple": {
         "type": "object",
-        "title": "TestStructWithTuple",
+        "title": "reflectapi_demo.tests.basic.TestStructWithTuple",
         "required": [
           "_f"
         ],
@@ -60,11 +56,15 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               }
             ]
           }
         }
+      },
+      "std.string.String": {
+        "description": "UTF-8 encoded string",
+        "type": "string"
       },
       "u8": {
         "description": "8-bit unsigned integer",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple12-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple12-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithTuple12"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithTuple12"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithTuple12"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithTuple12"
                 }
               }
             }
@@ -41,13 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "String": {
-        "description": "UTF-8 encoded string",
-        "type": "string"
-      },
-      "TestStructWithTuple12": {
+      "reflectapi_demo.tests.basic.TestStructWithTuple12": {
         "type": "object",
-        "title": "TestStructWithTuple12",
+        "title": "reflectapi_demo.tests.basic.TestStructWithTuple12",
         "required": [
           "_f"
         ],
@@ -60,41 +56,45 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               },
               {
                 "$ref": "#/components/schemas/u8"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               }
             ]
           }
         }
+      },
+      "std.string.String": {
+        "description": "UTF-8 encoded string",
+        "type": "string"
       },
       "u8": {
         "description": "8-bit unsigned integer",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithVec"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithVec"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithVec"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithVec"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithVec": {
+      "reflectapi_demo.tests.basic.TestStructWithVec": {
         "type": "object",
-        "title": "TestStructWithVec",
+        "title": "reflectapi_demo.tests.basic.TestStructWithVec",
         "required": [
           "_f"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_external-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_external-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithVecExternal"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithVecExternal"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithVecExternal"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithVecExternal"
                 }
               }
             }
@@ -41,25 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "String": {
-        "description": "UTF-8 encoded string",
-        "type": "string"
-      },
-      "TestStructNested": {
+      "reflectapi_demo.tests.basic.TestStructWithVecExternal": {
         "type": "object",
-        "title": "TestStructNested",
-        "required": [
-          "_f"
-        ],
-        "properties": {
-          "_f": {
-            "$ref": "#/components/schemas/String"
-          }
-        }
-      },
-      "TestStructWithVecExternal": {
-        "type": "object",
-        "title": "TestStructWithVecExternal",
+        "title": "reflectapi_demo.tests.basic.TestStructWithVecExternal",
         "required": [
           "_f"
         ],
@@ -68,10 +52,26 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "description": "Expandable array type",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TestStructNested"
+              "$ref": "#/components/schemas/reflectapi_demo.tests.test_lib.TestStructNested"
             }
           }
         }
+      },
+      "reflectapi_demo.tests.test_lib.TestStructNested": {
+        "type": "object",
+        "title": "reflectapi_demo.tests.test_lib.TestStructNested",
+        "required": [
+          "_f"
+        ],
+        "properties": {
+          "_f": {
+            "$ref": "#/components/schemas/std.string.String"
+          }
+        }
+      },
+      "std.string.String": {
+        "description": "UTF-8 encoded string",
+        "type": "string"
       }
     }
   }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_nested-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_nested-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithVecNested"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithVecNested"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithVecNested"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithVecNested"
                 }
               }
             }
@@ -41,25 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "String": {
-        "description": "UTF-8 encoded string",
-        "type": "string"
-      },
-      "TestStructNested": {
+      "reflectapi_demo.tests.basic.TestStructWithVecNested": {
         "type": "object",
-        "title": "TestStructNested",
-        "required": [
-          "_f"
-        ],
-        "properties": {
-          "_f": {
-            "$ref": "#/components/schemas/String"
-          }
-        }
-      },
-      "TestStructWithVecNested": {
-        "type": "object",
-        "title": "TestStructWithVecNested",
+        "title": "reflectapi_demo.tests.basic.TestStructWithVecNested",
         "required": [
           "_f"
         ],
@@ -71,11 +55,27 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
               "description": "Expandable array type",
               "type": "array",
               "items": {
-                "$ref": "#/components/schemas/TestStructNested"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.test_lib.TestStructNested"
               }
             }
           }
         }
+      },
+      "reflectapi_demo.tests.test_lib.TestStructNested": {
+        "type": "object",
+        "title": "reflectapi_demo.tests.test_lib.TestStructNested",
+        "required": [
+          "_f"
+        ],
+        "properties": {
+          "_f": {
+            "$ref": "#/components/schemas/std.string.String"
+          }
+        }
+      },
+      "std.string.String": {
+        "description": "UTF-8 encoded string",
+        "type": "string"
       }
     }
   }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_two-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_two-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithVecTwo"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithVecTwo"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithVecTwo"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.basic.TestStructWithVecTwo"
                 }
               }
             }
@@ -41,9 +41,13 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithVecTwo": {
+      "i8": {
+        "description": "8-bit signed integer",
+        "type": "integer"
+      },
+      "reflectapi_demo.tests.basic.TestStructWithVecTwo": {
         "type": "object",
-        "title": "TestStructWithVecTwo",
+        "title": "reflectapi_demo.tests.basic.TestStructWithVecTwo",
         "required": [
           "_f",
           "_f2"
@@ -64,10 +68,6 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             }
           }
         }
-      },
-      "i8": {
-        "description": "8-bit signed integer",
-        "type": "integer"
       },
       "u8": {
         "description": "8-bit unsigned integer",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_rename_num-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_rename_num-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Nums"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.enums.Nums"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Nums"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.enums.Nums"
                 }
               }
             }
@@ -41,7 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "Nums": {
+      "reflectapi_demo.tests.enums.Nums": {
         "oneOf": [
           {
             "type": "string"

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_adjacently_tagged-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_adjacently_tagged-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestEmptyVariantsAdjacentlyTagged"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEmptyVariantsAdjacentlyTagged"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestEmptyVariantsAdjacentlyTagged"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEmptyVariantsAdjacentlyTagged"
                 }
               }
             }
@@ -41,7 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestEmptyVariantsAdjacentlyTagged": {
+      "reflectapi_demo.tests.serde.TestEmptyVariantsAdjacentlyTagged": {
         "oneOf": [
           {
             "type": "object",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_externally_tagged-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_externally_tagged-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestEmptyVariantsExternallyTagged"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEmptyVariantsExternallyTagged"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestEmptyVariantsExternallyTagged"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEmptyVariantsExternallyTagged"
                 }
               }
             }
@@ -41,7 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestEmptyVariantsExternallyTagged": {
+      "reflectapi_demo.tests.serde.TestEmptyVariantsExternallyTagged": {
         "oneOf": [
           {
             "type": "string"

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_internally_tagged-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_internally_tagged-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestEmptyVariantsInterallyTagged"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEmptyVariantsInterallyTagged"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestEmptyVariantsInterallyTagged"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEmptyVariantsInterallyTagged"
                 }
               }
             }
@@ -41,11 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "String": {
-        "description": "UTF-8 encoded string",
-        "type": "string"
-      },
-      "TestEmptyVariantsInterallyTagged": {
+      "reflectapi_demo.tests.serde.TestEmptyVariantsInterallyTagged": {
         "oneOf": [
           {
             "type": "object",
@@ -55,7 +51,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             ],
             "properties": {
               "type": {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               }
             }
           },
@@ -67,7 +63,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             ],
             "properties": {
               "type": {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               }
             }
           }
@@ -75,6 +71,10 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
         "discriminator": {
           "propertyName": "type"
         }
+      },
+      "std.string.String": {
+        "description": "UTF-8 encoded string",
+        "type": "string"
       }
     }
   }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/MyEnum"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.MyEnum"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MyEnum"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.MyEnum"
                 }
               }
             }
@@ -41,7 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "MyEnum": {
+      "reflectapi_demo.tests.serde.MyEnum": {
         "oneOf": [
           {
             "type": "string"

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestEnumRenameAll"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumRenameAll"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestEnumRenameAll"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumRenameAll"
                 }
               }
             }
@@ -41,7 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestEnumRenameAll": {
+      "reflectapi_demo.tests.serde.TestEnumRenameAll": {
         "oneOf": [
           {
             "type": "string"

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all_on_variant-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all_on_variant-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestEnumRenameAllOnVariant"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumRenameAllOnVariant"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestEnumRenameAllOnVariant"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumRenameAllOnVariant"
                 }
               }
             }
@@ -41,7 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestEnumRenameAllOnVariant": {
+      "reflectapi_demo.tests.serde.TestEnumRenameAllOnVariant": {
         "oneOf": [
           {
             "type": "object",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_variant_field-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_variant_field-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestEnumRenameVariantField"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumRenameVariantField"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestEnumRenameVariantField"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumRenameVariantField"
                 }
               }
             }
@@ -41,7 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestEnumRenameVariantField": {
+      "reflectapi_demo.tests.serde.TestEnumRenameVariantField": {
         "oneOf": [
           {
             "type": "object",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestEnumTag"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumTag"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestEnumTag"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumTag"
                 }
               }
             }
@@ -41,11 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "String": {
-        "description": "UTF-8 encoded string",
-        "type": "string"
-      },
-      "TestEnumTag": {
+      "reflectapi_demo.tests.serde.TestEnumTag": {
         "oneOf": [
           {
             "type": "object",
@@ -59,7 +55,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
                 "$ref": "#/components/schemas/u8"
               },
               "type": {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               }
             }
           },
@@ -75,7 +71,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
                 "$ref": "#/components/schemas/u8"
               },
               "type": {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               }
             }
           }
@@ -83,6 +79,10 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
         "discriminator": {
           "propertyName": "type"
         }
+      },
+      "std.string.String": {
+        "description": "UTF-8 encoded string",
+        "type": "string"
       },
       "u8": {
         "description": "8-bit unsigned integer",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestEnumTagContent"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumTagContent"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestEnumTagContent"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumTagContent"
                 }
               }
             }
@@ -41,7 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestEnumTagContent": {
+      "reflectapi_demo.tests.serde.TestEnumTagContent": {
         "oneOf": [
           {
             "type": "object",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content_rename_all-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content_rename_all-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestEnumTagContentRenameAll"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumTagContentRenameAll"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestEnumTagContentRenameAll"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumTagContentRenameAll"
                 }
               }
             }
@@ -41,7 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestEnumTagContentRenameAll": {
+      "reflectapi_demo.tests.serde.TestEnumTagContentRenameAll": {
         "oneOf": [
           {
             "type": "object",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_untagged-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_untagged-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestEnumUntagged"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumUntagged"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestEnumUntagged"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumUntagged"
                 }
               }
             }
@@ -41,7 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestEnumUntagged": {
+      "reflectapi_demo.tests.serde.TestEnumUntagged": {
         "oneOf": [
           {
             "type": "array",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_field_skip-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_field_skip-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestEnumWithFieldSkip"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumWithFieldSkip"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestEnumWithFieldSkip"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumWithFieldSkip"
                 }
               }
             }
@@ -41,7 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestEnumWithFieldSkip": {
+      "reflectapi_demo.tests.serde.TestEnumWithFieldSkip": {
         "oneOf": [
           {
             "type": "object",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_rename_to_invalid_chars-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_rename_to_invalid_chars-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestEnumWithRenameToInvalidChars"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumWithRenameToInvalidChars"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestEnumWithRenameToInvalidChars"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumWithRenameToInvalidChars"
                 }
               }
             }
@@ -41,7 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestEnumWithRenameToInvalidChars": {
+      "reflectapi_demo.tests.serde.TestEnumWithRenameToInvalidChars": {
         "oneOf": [
           {
             "type": "object",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_other-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_other-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestEnumWithVariantOther"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumWithVariantOther"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestEnumWithVariantOther"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumWithVariantOther"
                 }
               }
             }
@@ -41,11 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "String": {
-        "description": "UTF-8 encoded string",
-        "type": "string"
-      },
-      "TestEnumWithVariantOther": {
+      "reflectapi_demo.tests.serde.TestEnumWithVariantOther": {
         "oneOf": [
           {
             "type": "object",
@@ -55,7 +51,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             ],
             "properties": {
               "type": {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               }
             }
           }
@@ -63,6 +59,10 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
         "discriminator": {
           "propertyName": "type"
         }
+      },
+      "std.string.String": {
+        "description": "UTF-8 encoded string",
+        "type": "string"
       }
     }
   }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestEnumWithVariantSkip"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumWithVariantSkip"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestEnumWithVariantSkip"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumWithVariantSkip"
                 }
               }
             }
@@ -41,7 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestEnumWithVariantSkip": {
+      "reflectapi_demo.tests.serde.TestEnumWithVariantSkip": {
         "oneOf": []
       }
     }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_deserialize-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_deserialize-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestEnumWithVariantSkipDeserialize"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumWithVariantSkipDeserialize"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestEnumWithVariantSkipDeserialize"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumWithVariantSkipDeserialize"
                 }
               }
             }
@@ -41,7 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestEnumWithVariantSkipDeserialize": {
+      "reflectapi_demo.tests.serde.TestEnumWithVariantSkipDeserialize": {
         "oneOf": []
       }
     }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_serialize-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_serialize-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestEnumWithVariantSkipSerialize"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumWithVariantSkipSerialize"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestEnumWithVariantSkipSerialize"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumWithVariantSkipSerialize"
                 }
               }
             }
@@ -41,7 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestEnumWithVariantSkipSerialize": {
+      "reflectapi_demo.tests.serde.TestEnumWithVariantSkipSerialize": {
         "oneOf": [
           {
             "type": "string"

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_untagged-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_untagged-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestEnumWithVariantUntagged"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumWithVariantUntagged"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestEnumWithVariantUntagged"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestEnumWithVariantUntagged"
                 }
               }
             }
@@ -41,7 +41,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestEnumWithVariantUntagged": {
+      "reflectapi_demo.tests.serde.TestEnumWithVariantUntagged": {
         "oneOf": [
           {
             "$ref": "#/components/schemas/u8"

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_from-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_from-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructFrom"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructFrom"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructFromProxy"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructFromProxy"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructFrom": {
+      "reflectapi_demo.tests.serde.TestStructFrom": {
         "type": "object",
-        "title": "TestStructFrom",
+        "title": "reflectapi_demo.tests.serde.TestStructFrom",
         "required": [
           "f"
         ],
@@ -53,9 +53,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           }
         }
       },
-      "TestStructFromProxy": {
+      "reflectapi_demo.tests.serde.TestStructFromProxy": {
         "type": "object",
-        "title": "TestStructFromProxy",
+        "title": "reflectapi_demo.tests.serde.TestStructFromProxy",
         "required": [
           "f"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_into-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_into-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructIntoProxy"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructIntoProxy"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructIntoProxy"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructIntoProxy"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructIntoProxy": {
+      "reflectapi_demo.tests.serde.TestStructIntoProxy": {
         "type": "object",
-        "title": "TestStructIntoProxy",
+        "title": "reflectapi_demo.tests.serde.TestStructIntoProxy",
         "required": [
           "f"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/MyStruct"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.MyStruct"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MyStruct"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.MyStruct"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "MyStruct": {
+      "reflectapi_demo.tests.serde.MyStruct": {
         "type": "object",
-        "title": "MyStruct",
+        "title": "reflectapi_demo.tests.serde.MyStruct",
         "properties": {}
       }
     }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructRenameAll"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructRenameAll"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructRenameAll"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructRenameAll"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructRenameAll": {
+      "reflectapi_demo.tests.serde.TestStructRenameAll": {
         "type": "object",
-        "title": "TestStructRenameAll",
+        "title": "reflectapi_demo.tests.serde.TestStructRenameAll",
         "required": [
           "fieldName"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_differently-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_differently-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructRenameAllDifferently"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructRenameAllDifferently"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructRenameAllDifferently"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructRenameAllDifferently"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructRenameAllDifferently": {
+      "reflectapi_demo.tests.serde.TestStructRenameAllDifferently": {
         "type": "object",
-        "title": "TestStructRenameAllDifferently",
+        "title": "reflectapi_demo.tests.serde.TestStructRenameAllDifferently",
         "required": [
           "field_name"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_pascal_case-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_pascal_case-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructRenameAllPascalCase"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructRenameAllPascalCase"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructRenameAllPascalCase"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructRenameAllPascalCase"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructRenameAllPascalCase": {
+      "reflectapi_demo.tests.serde.TestStructRenameAllPascalCase": {
         "type": "object",
-        "title": "TestStructRenameAllPascalCase",
+        "title": "reflectapi_demo.tests.serde.TestStructRenameAllPascalCase",
         "required": [
           "FieldName"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_differently-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_differently-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/MyStructInput"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.MyStructInput"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/MyStructOutput"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.MyStructOutput"
                 }
               }
             }
@@ -41,14 +41,14 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "MyStructInput": {
+      "reflectapi_demo.tests.serde.MyStructInput": {
         "type": "object",
-        "title": "MyStructInput",
+        "title": "reflectapi_demo.tests.serde.MyStructInput",
         "properties": {}
       },
-      "MyStructOutput": {
+      "reflectapi_demo.tests.serde.MyStructOutput": {
         "type": "object",
-        "title": "MyStructOutput",
+        "title": "reflectapi_demo.tests.serde.MyStructOutput",
         "properties": {}
       }
     }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_field-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_field-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructRenameField"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructRenameField"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructRenameField"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructRenameField"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructRenameField": {
+      "reflectapi_demo.tests.serde.TestStructRenameField": {
         "type": "object",
-        "title": "TestStructRenameField",
+        "title": "reflectapi_demo.tests.serde.TestStructRenameField",
         "required": [
           "fieldName"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_try_from-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_try_from-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructTryFrom"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructTryFrom"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructTryFormProxy"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructTryFormProxy"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructTryFormProxy": {
+      "reflectapi_demo.tests.serde.TestStructTryFormProxy": {
         "type": "object",
-        "title": "TestStructTryFormProxy",
+        "title": "reflectapi_demo.tests.serde.TestStructTryFormProxy",
         "required": [
           "f"
         ],
@@ -53,9 +53,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           }
         }
       },
-      "TestStructTryFrom": {
+      "reflectapi_demo.tests.serde.TestStructTryFrom": {
         "type": "object",
-        "title": "TestStructTryFrom",
+        "title": "reflectapi_demo.tests.serde.TestStructTryFrom",
         "required": [
           "f"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithFlatten"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithFlatten"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithFlatten"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithFlatten"
                 }
               }
             }
@@ -41,21 +41,21 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithFlatten": {
+      "reflectapi_demo.tests.serde.TestStructWithFlatten": {
         "type": "object",
-        "title": "TestStructWithFlatten",
+        "title": "reflectapi_demo.tests.serde.TestStructWithFlatten",
         "required": [
           "g"
         ],
         "properties": {
           "g": {
-            "$ref": "#/components/schemas/TestStructWithFlattenNested"
+            "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithFlattenNested"
           }
         }
       },
-      "TestStructWithFlattenNested": {
+      "reflectapi_demo.tests.serde.TestStructWithFlattenNested": {
         "type": "object",
-        "title": "TestStructWithFlattenNested",
+        "title": "reflectapi_demo.tests.serde.TestStructWithFlattenNested",
         "required": [
           "f"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithFlattenOptional"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithFlattenOptional"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithFlattenOptional"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithFlattenOptional"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithFlattenNested": {
+      "reflectapi_demo.tests.serde.TestStructWithFlattenNested": {
         "type": "object",
-        "title": "TestStructWithFlattenNested",
+        "title": "reflectapi_demo.tests.serde.TestStructWithFlattenNested",
         "required": [
           "f"
         ],
@@ -53,9 +53,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           }
         }
       },
-      "TestStructWithFlattenOptional": {
+      "reflectapi_demo.tests.serde.TestStructWithFlattenOptional": {
         "type": "object",
-        "title": "TestStructWithFlattenOptional",
+        "title": "reflectapi_demo.tests.serde.TestStructWithFlattenOptional",
         "properties": {
           "g": {
             "oneOf": [
@@ -64,7 +64,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
                 "type": "null"
               },
               {
-                "$ref": "#/components/schemas/TestStructWithFlattenNested"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithFlattenNested"
               }
             ]
           }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional_and_required-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional_and_required-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithFlattenOptionalAndRequired"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithFlattenOptionalAndRequired"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithFlattenOptionalAndRequired"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithFlattenOptionalAndRequired"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructRenameAll": {
+      "reflectapi_demo.tests.serde.TestStructRenameAll": {
         "type": "object",
-        "title": "TestStructRenameAll",
+        "title": "reflectapi_demo.tests.serde.TestStructRenameAll",
         "required": [
           "fieldName"
         ],
@@ -53,9 +53,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           }
         }
       },
-      "TestStructWithFlattenNested": {
+      "reflectapi_demo.tests.serde.TestStructWithFlattenNested": {
         "type": "object",
-        "title": "TestStructWithFlattenNested",
+        "title": "reflectapi_demo.tests.serde.TestStructWithFlattenNested",
         "required": [
           "f"
         ],
@@ -65,9 +65,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           }
         }
       },
-      "TestStructWithFlattenOptionalAndRequired": {
+      "reflectapi_demo.tests.serde.TestStructWithFlattenOptionalAndRequired": {
         "type": "object",
-        "title": "TestStructWithFlattenOptionalAndRequired",
+        "title": "reflectapi_demo.tests.serde.TestStructWithFlattenOptionalAndRequired",
         "required": [
           "k"
         ],
@@ -79,12 +79,12 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
                 "type": "null"
               },
               {
-                "$ref": "#/components/schemas/TestStructWithFlattenNested"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithFlattenNested"
               }
             ]
           },
           "k": {
-            "$ref": "#/components/schemas/TestStructRenameAll"
+            "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructRenameAll"
           }
         }
       },

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_invalid_chars-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_invalid_chars-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithRenameToInvalidChars"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithRenameToInvalidChars"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithRenameToInvalidChars"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithRenameToInvalidChars"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithRenameToInvalidChars": {
+      "reflectapi_demo.tests.serde.TestStructWithRenameToInvalidChars": {
         "type": "object",
-        "title": "TestStructWithRenameToInvalidChars",
+        "title": "reflectapi_demo.tests.serde.TestStructWithRenameToInvalidChars",
         "required": [
           "field-name&&"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_kebab_case-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_kebab_case-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/struct_name"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.struct_name"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/struct_name"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.struct_name"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "struct_name": {
+      "reflectapi_demo.tests.serde.struct_name": {
         "type": "object",
-        "title": "struct_name",
+        "title": "reflectapi_demo.tests.serde.struct_name",
         "required": [
           "field-name"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_default-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_default-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithSerdeDefault"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithSerdeDefault"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithSerdeDefault"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithSerdeDefault"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithSerdeDefault": {
+      "reflectapi_demo.tests.serde.TestStructWithSerdeDefault": {
         "type": "object",
-        "title": "TestStructWithSerdeDefault",
+        "title": "reflectapi_demo.tests.serde.TestStructWithSerdeDefault",
         "properties": {
           "f": {
             "$ref": "#/components/schemas/u8"

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithSerdeSkip"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithSerdeSkip"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithSerdeSkip"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithSerdeSkip"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithSerdeSkip": {
+      "reflectapi_demo.tests.serde.TestStructWithSerdeSkip": {
         "type": "object",
-        "title": "TestStructWithSerdeSkip",
+        "title": "reflectapi_demo.tests.serde.TestStructWithSerdeSkip",
         "properties": {}
       }
     }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_deserialize-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_deserialize-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithSerdeSkipDeserialize"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithSerdeSkipDeserialize"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithSerdeSkipDeserialize"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithSerdeSkipDeserialize"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithSerdeSkipDeserialize": {
+      "reflectapi_demo.tests.serde.TestStructWithSerdeSkipDeserialize": {
         "type": "object",
-        "title": "TestStructWithSerdeSkipDeserialize",
+        "title": "reflectapi_demo.tests.serde.TestStructWithSerdeSkipDeserialize",
         "properties": {}
       }
     }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithSerdeSkipSerialize"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithSerdeSkipSerialize"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithSerdeSkipSerialize"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithSerdeSkipSerialize"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithSerdeSkipSerialize": {
+      "reflectapi_demo.tests.serde.TestStructWithSerdeSkipSerialize": {
         "type": "object",
-        "title": "TestStructWithSerdeSkipSerialize",
+        "title": "reflectapi_demo.tests.serde.TestStructWithSerdeSkipSerialize",
         "required": [
           "_f"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize_if-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize_if-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestStructWithSerdeSkipSerializeIf"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithSerdeSkipSerializeIf"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestStructWithSerdeSkipSerializeIf"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestStructWithSerdeSkipSerializeIf"
                 }
               }
             }
@@ -41,9 +41,9 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestStructWithSerdeSkipSerializeIf": {
+      "reflectapi_demo.tests.serde.TestStructWithSerdeSkipSerializeIf": {
         "type": "object",
-        "title": "TestStructWithSerdeSkipSerializeIf",
+        "title": "reflectapi_demo.tests.serde.TestStructWithSerdeSkipSerializeIf",
         "required": [
           "f"
         ],

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__unit_struct-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__unit_struct-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestUnitStruct"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestUnitStruct"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestUnitStruct"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestUnitStruct"
                 }
               }
             }
@@ -41,15 +41,15 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestUnitStruct": {
+      "reflectapi_demo.tests.serde.TestUnitStruct": {
         "type": "array",
         "prefixItems": [
           {
-            "$ref": "#/components/schemas/Tuple0"
+            "$ref": "#/components/schemas/std.tuple.Tuple0"
           }
         ]
       },
-      "Tuple0": {
+      "std.tuple.Tuple0": {
         "description": "Unit type",
         "type": "null"
       }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__unit_tuple_struct-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__unit_tuple_struct-4.snap
@@ -18,7 +18,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TestUnitTupleStruct"
+                "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestUnitTupleStruct"
               }
             }
           },
@@ -30,7 +30,7 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TestUnitTupleStruct"
+                  "$ref": "#/components/schemas/reflectapi_demo.tests.serde.TestUnitTupleStruct"
                 }
               }
             }
@@ -41,15 +41,15 @@ expression: "reflectapi::codegen::openapi::Spec::from(&schema)"
   },
   "components": {
     "schemas": {
-      "TestUnitTupleStruct": {
+      "reflectapi_demo.tests.serde.TestUnitTupleStruct": {
         "type": "array",
         "prefixItems": [
           {
-            "$ref": "#/components/schemas/Tuple0"
+            "$ref": "#/components/schemas/std.tuple.Tuple0"
           }
         ]
       },
-      "Tuple0": {
+      "std.tuple.Tuple0": {
         "description": "Unit type",
         "type": "null"
       }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__write_openapi_spec.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__write_openapi_spec.snap
@@ -40,7 +40,7 @@ expression: s
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PetsCreateRequest"
+                "$ref": "#/components/schemas/myapi.proto.PetsCreateRequest"
               }
             }
           },
@@ -66,7 +66,7 @@ expression: s
             "in": "header",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/String"
+              "$ref": "#/components/schemas/std.string.String"
             }
           }
         ]
@@ -89,7 +89,7 @@ expression: s
                       "type": "null"
                     },
                     {
-                      "$ref": "#/components/schemas/Pet"
+                      "$ref": "#/components/schemas/myapi.model.Pet"
                     }
                   ]
                 }
@@ -103,7 +103,7 @@ expression: s
             "in": "header",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/String"
+              "$ref": "#/components/schemas/std.string.String"
             }
           }
         ]
@@ -118,7 +118,7 @@ expression: s
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PetsListRequest"
+                "$ref": "#/components/schemas/myapi.proto.PetsListRequest"
               }
             }
           },
@@ -131,7 +131,7 @@ expression: s
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "title": "Paginated",
+                  "title": "myapi.proto.Paginated",
                   "required": [
                     "items"
                   ],
@@ -143,7 +143,7 @@ expression: s
                           "type": "null"
                         },
                         {
-                          "$ref": "#/components/schemas/String"
+                          "$ref": "#/components/schemas/std.string.String"
                         }
                       ]
                     },
@@ -151,7 +151,7 @@ expression: s
                       "description": "Expandable array type",
                       "type": "array",
                       "items": {
-                        "$ref": "#/components/schemas/Pet"
+                        "$ref": "#/components/schemas/myapi.model.Pet"
                       }
                     }
                   }
@@ -166,7 +166,7 @@ expression: s
             "in": "header",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/String"
+              "$ref": "#/components/schemas/std.string.String"
             }
           }
         ]
@@ -181,7 +181,7 @@ expression: s
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PetsRemoveRequest"
+                "$ref": "#/components/schemas/myapi.proto.PetsRemoveRequest"
               }
             }
           },
@@ -207,7 +207,7 @@ expression: s
             "in": "header",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/String"
+              "$ref": "#/components/schemas/std.string.String"
             }
           }
         ]
@@ -222,7 +222,7 @@ expression: s
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/PetsUpdateRequest"
+                "$ref": "#/components/schemas/myapi.proto.PetsUpdateRequest"
               }
             }
           },
@@ -248,7 +248,7 @@ expression: s
             "in": "header",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/String"
+              "$ref": "#/components/schemas/std.string.String"
             }
           }
         ]
@@ -257,7 +257,11 @@ expression: s
   },
   "components": {
     "schemas": {
-      "Behavior": {
+      "f64": {
+        "description": "64-bit floating point number",
+        "type": "number"
+      },
+      "myapi.model.Behavior": {
         "oneOf": [
           {
             "type": "string"
@@ -276,7 +280,7 @@ expression: s
                     "$ref": "#/components/schemas/f64"
                   },
                   {
-                    "$ref": "#/components/schemas/String"
+                    "$ref": "#/components/schemas/std.string.String"
                   }
                 ]
               }
@@ -297,10 +301,10 @@ expression: s
                 ],
                 "properties": {
                   "description": {
-                    "$ref": "#/components/schemas/String"
+                    "$ref": "#/components/schemas/std.string.String"
                   },
                   "notes": {
-                    "$ref": "#/components/schemas/String"
+                    "$ref": "#/components/schemas/std.string.String"
                   }
                 }
               }
@@ -308,7 +312,7 @@ expression: s
           }
         ]
       },
-      "Kind": {
+      "myapi.model.Kind": {
         "oneOf": [
           {
             "description": " A dog",
@@ -320,9 +324,9 @@ expression: s
           }
         ]
       },
-      "Pet": {
+      "myapi.model.Pet": {
         "type": "object",
-        "title": "Pet",
+        "title": "myapi.model.Pet",
         "required": [
           "name",
           "kind"
@@ -343,28 +347,28 @@ expression: s
             "description": "Expandable array type",
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Behavior"
+              "$ref": "#/components/schemas/myapi.model.Behavior"
             }
           },
           "kind": {
-            "$ref": "#/components/schemas/Kind"
+            "$ref": "#/components/schemas/myapi.model.Kind"
           },
           "name": {
-            "$ref": "#/components/schemas/String"
+            "$ref": "#/components/schemas/std.string.String"
           }
         }
       },
-      "PetsCreateRequest": {
+      "myapi.proto.PetsCreateRequest": {
         "type": "array",
         "prefixItems": [
           {
-            "$ref": "#/components/schemas/Pet"
+            "$ref": "#/components/schemas/myapi.model.Pet"
           }
         ]
       },
-      "PetsListRequest": {
+      "myapi.proto.PetsListRequest": {
         "type": "object",
-        "title": "PetsListRequest",
+        "title": "myapi.proto.PetsListRequest",
         "properties": {
           "cursor": {
             "oneOf": [
@@ -373,7 +377,7 @@ expression: s
                 "type": "null"
               },
               {
-                "$ref": "#/components/schemas/String"
+                "$ref": "#/components/schemas/std.string.String"
               }
             ]
           },
@@ -390,21 +394,21 @@ expression: s
           }
         }
       },
-      "PetsRemoveRequest": {
+      "myapi.proto.PetsRemoveRequest": {
         "type": "object",
-        "title": "PetsRemoveRequest",
+        "title": "myapi.proto.PetsRemoveRequest",
         "required": [
           "name"
         ],
         "properties": {
           "name": {
-            "$ref": "#/components/schemas/String"
+            "$ref": "#/components/schemas/std.string.String"
           }
         }
       },
-      "PetsUpdateRequest": {
+      "myapi.proto.PetsUpdateRequest": {
         "type": "object",
-        "title": "PetsUpdateRequest",
+        "title": "myapi.proto.PetsUpdateRequest",
         "required": [
           "name"
         ],
@@ -430,7 +434,7 @@ expression: s
                 "description": "Expandable array type",
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/Behavior"
+                  "$ref": "#/components/schemas/myapi.model.Behavior"
                 }
               }
             ]
@@ -442,22 +446,18 @@ expression: s
                 "type": "null"
               },
               {
-                "$ref": "#/components/schemas/Kind"
+                "$ref": "#/components/schemas/myapi.model.Kind"
               }
             ]
           },
           "name": {
-            "$ref": "#/components/schemas/String"
+            "$ref": "#/components/schemas/std.string.String"
           }
         }
       },
-      "String": {
+      "std.string.String": {
         "description": "UTF-8 encoded string",
         "type": "string"
-      },
-      "f64": {
-        "description": "64-bit floating point number",
-        "type": "number"
       },
       "u8": {
         "description": "8-bit unsigned integer",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__write_openapi_spec.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__write_openapi_spec.snap
@@ -131,7 +131,7 @@ expression: s
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "title": "myapi.proto.Paginated",
+                  "title": "myapi.proto.Paginated<myapi.model.Pet>",
                   "required": [
                     "items"
                   ],

--- a/reflectapi/src/codegen/openapi.rs
+++ b/reflectapi/src/codegen/openapi.rs
@@ -730,12 +730,8 @@ impl Converter {
     }
 }
 
-// Take the last segment of the path as the name.
 fn normalize(name: impl AsRef<str>) -> String {
-    let name = name.as_ref();
-    name.rsplit_once("::")
-        .map_or(name, |(_, name)| name)
-        .to_owned()
+    name.as_ref().replace("::", ".")
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]

--- a/reflectapi/src/codegen/openapi.rs
+++ b/reflectapi/src/codegen/openapi.rs
@@ -377,6 +377,7 @@ impl Converter {
             crate::Type::Struct(strukt) => match self.struct_to_schema(
                 schema,
                 kind,
+                ty_ref,
                 &strukt.clone().instantiate(&ty_ref.arguments),
             ) {
                 InlineOrRef::Inline(schema) => schema,
@@ -405,6 +406,7 @@ impl Converter {
                     match self.enum_to_schema(
                         schema,
                         kind,
+                        ty_ref,
                         &adt.clone().instantiate(&ty_ref.arguments),
                     ) {
                         InlineOrRef::Inline(schema) => schema,
@@ -508,13 +510,14 @@ impl Converter {
         &mut self,
         schema: &crate::Schema,
         kind: Kind,
+        type_ref: &crate::TypeReference,
         adt: &crate::Enum,
     ) -> InlineOrRef<Schema> {
         assert!(adt.parameters.is_empty(), "expect enum to be instantiated");
 
         let subschemas = adt
             .variants()
-            .map(|variant| self.variant_to_schema(schema, kind, adt, variant))
+            .map(|variant| self.variant_to_schema(schema, kind, type_ref, adt, variant))
             .collect::<Vec<_>>();
 
         let schema = match adt.representation() {
@@ -555,10 +558,14 @@ impl Converter {
         &mut self,
         schema: &crate::Schema,
         kind: Kind,
+        type_ref: &crate::TypeReference,
         adt: &crate::Enum,
         variant: &crate::Variant,
     ) -> InlineOrRef<Schema> {
         assert!(adt.parameters.is_empty(), "expect enum to be instantiated");
+
+        let type_ref =
+            crate::TypeReference::new(variant.name().to_owned(), type_ref.arguments.clone());
 
         let mut strukt = crate::Struct {
             name: variant.name().to_owned(),
@@ -588,7 +595,7 @@ impl Converter {
 
                     let ty = match variant.fields {
                         reflectapi_schema::Fields::Named(_) => Type::Object {
-                            title: variant.name().to_owned(),
+                            title: fmt_type_ref(&type_ref),
                             required: vec![],
                             properties: BTreeMap::new(),
                         },
@@ -611,11 +618,11 @@ impl Converter {
                     FlatSchema {
                         description: variant.description().to_owned(),
                         ty: Type::Object {
-                            title: variant.name().to_owned(),
+                            title: fmt_type_ref(&type_ref),
                             required: vec![variant.serde_name().to_owned()],
                             properties: BTreeMap::from([(
                                 variant.serde_name().to_owned(),
-                                self.struct_to_schema(schema, kind, &strukt),
+                                self.struct_to_schema(schema, kind, &type_ref, &strukt),
                             )]),
                         },
                     }
@@ -627,7 +634,7 @@ impl Converter {
                     FlatSchema {
                         description: variant.description().to_owned(),
                         ty: Type::Object {
-                            title: variant.name().to_owned(),
+                            title: fmt_type_ref(&type_ref),
                             required: vec![tag.to_owned(), content.to_owned()],
                             properties: BTreeMap::from([
                                 (
@@ -642,7 +649,7 @@ impl Converter {
                                 ),
                                 (
                                     content.to_owned(),
-                                    self.struct_to_schema(schema, kind, &strukt),
+                                    self.struct_to_schema(schema, kind, &type_ref, &strukt),
                                 ),
                             ]),
                         },
@@ -675,13 +682,14 @@ impl Converter {
             crate::Representation::None => {}
         }
 
-        self.struct_to_schema(schema, kind, &strukt)
+        self.struct_to_schema(schema, kind, &type_ref, &strukt)
     }
 
     fn struct_to_schema(
         &mut self,
         schema: &crate::Schema,
         kind: Kind,
+        type_ref: &crate::TypeReference,
         strukt: &crate::Struct,
     ) -> InlineOrRef<Schema> {
         assert!(
@@ -696,7 +704,7 @@ impl Converter {
 
         let ty = if strukt.fields().all(|f| f.is_named()) {
             Type::Object {
-                title: normalize(strukt.name()),
+                title: fmt_type_ref(type_ref),
                 required: strukt
                     .fields()
                     .filter(|f| f.required)
@@ -732,6 +740,22 @@ impl Converter {
 
 fn normalize(name: impl AsRef<str>) -> String {
     name.as_ref().replace("::", ".")
+}
+
+fn fmt_type_ref(r: &crate::TypeReference) -> String {
+    if r.arguments.is_empty() {
+        normalize(&r.name)
+    } else {
+        format!(
+            "{}<{}>",
+            normalize(&r.name),
+            r.arguments
+                .iter()
+                .map(fmt_type_ref)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]


### PR DESCRIPTION
- **keep type namespaces in openapi spec**
- **include generic parameters in openapi type titles**
