### PR TITLE
move rust helper code to `reflectapi::rt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,6 +1469,7 @@ dependencies = [
  "indexmap",
  "reflectapi-derive",
  "reflectapi-schema",
+ "reqwest",
  "rmp-serde",
  "rust_decimal",
  "serde",
@@ -1526,12 +1527,8 @@ dependencies = [
 name = "reflectapi-demo-client-generated"
 version = "0.1.0"
 dependencies = [
- "bytes",
- "http 1.1.0",
  "reflectapi",
- "reqwest",
  "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,4 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-# this is the only one which is referenced via workspace dependency
 reflectapi = { path = "reflectapi" }

--- a/reflectapi-demo/clients/rust/Cargo.toml
+++ b/reflectapi-demo/clients/rust/Cargo.toml
@@ -6,9 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reflectapi-demo-client-generated = { path = "generated", features = [
-    "reqwest",
-] }
+reflectapi-demo-client-generated = { path = "generated" }
 
 tokio = { version = "1.38.0", features = ["full"] }
 reqwest = { version = "0.12.2" }

--- a/reflectapi-demo/clients/rust/generated/Cargo.toml
+++ b/reflectapi-demo/clients/rust/generated/Cargo.toml
@@ -6,15 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reflectapi = { workspace = true }
-
-bytes = "1.5.0"
+reflectapi = { workspace = true, features = ["rt", "reqwest"] }
 serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.116"
 
-http = "1.1.0"
-
-reqwest = { version = "0.12.2", optional = true }
-
-[features]
-reqwest = ["dep:reqwest"]

--- a/reflectapi-demo/clients/rust/generated/src/generated.rs
+++ b/reflectapi-demo/clients/rust/generated/src/generated.rs
@@ -8,154 +8,19 @@
 #![allow(dead_code)]
 
 pub use interface::Interface;
-/* <----- */
-
-pub trait Client {
-    type Error;
-
-    fn request(
-        &self,
-        path: &str,
-        body: bytes::Bytes,
-        headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
-}
-
-pub enum Error<AE, NE> {
-    Application(AE),
-    Network(NE),
-    Protocol {
-        info: String,
-        stage: ProtocolErrorStage,
-    },
-    Server(http::StatusCode, bytes::Bytes),
-}
-
-impl<AE: core::fmt::Debug, NE: core::fmt::Debug> core::fmt::Debug for Error<AE, NE> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Error::Application(err) => write!(f, "Application error: {err:?}"),
-            Error::Network(err) => write!(f, "Network error: {err:?}"),
-            Error::Protocol { info, stage } => write!(f, "Protocol error: {info} at {stage:?}"),
-            Error::Server(status, body) => write!(
-                f,
-                "Server error: {status} with body: {}",
-                String::from_utf8_lossy(body)
-            ),
-        }
-    }
-}
-
-impl<AE: core::fmt::Display, NE: core::fmt::Display> core::fmt::Display for Error<AE, NE> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Error::Application(err) => write!(f, "Application error: {err}"),
-            Error::Network(err) => write!(f, "Network error: {err}"),
-            Error::Protocol { info, stage } => write!(f, "Protocol error: {info} at {stage}"),
-            Error::Server(status, body) => write!(
-                f,
-                "Server error: {status} with body: {}",
-                String::from_utf8_lossy(body)
-            ),
-        }
-    }
-}
-
-// TODO change to core::error::Error when we upgrade rust
-impl<AE: std::error::Error, NE: std::error::Error> std::error::Error for Error<AE, NE> {}
-
-pub enum ProtocolErrorStage {
-    SerializeRequestBody,
-    SerializeRequestHeaders,
-    DeserializeResponseBody(bytes::Bytes),
-    DeserializeResponseError(http::StatusCode, bytes::Bytes),
-}
-
-impl core::fmt::Display for ProtocolErrorStage {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            ProtocolErrorStage::SerializeRequestBody => {
-                write!(f, "failed to serialize request body")
-            }
-            ProtocolErrorStage::SerializeRequestHeaders => {
-                write!(f, "failed to serialize request headers")
-            }
-            ProtocolErrorStage::DeserializeResponseBody(body) => write!(
-                f,
-                "failed to deserialize response body: {}",
-                String::from_utf8_lossy(body)
-            ),
-            ProtocolErrorStage::DeserializeResponseError(status, body) => write!(
-                f,
-                "failed to deserialize response error: {} with body: {}",
-                status,
-                String::from_utf8_lossy(body)
-            ),
-        }
-    }
-}
-
-impl core::fmt::Debug for ProtocolErrorStage {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            ProtocolErrorStage::SerializeRequestBody => write!(f, "SerializeRequestBody"),
-            ProtocolErrorStage::SerializeRequestHeaders => write!(f, "SerializeRequestHeaders"),
-            ProtocolErrorStage::DeserializeResponseBody(body) => write!(
-                f,
-                "DeserializeResponseBody({:?})",
-                String::from_utf8_lossy(body)
-            ),
-            ProtocolErrorStage::DeserializeResponseError(status, body) => write!(
-                f,
-                "DeserializeResponseError({status}, {:?})",
-                String::from_utf8_lossy(body)
-            ),
-        }
-    }
-}
-
-#[cfg(feature = "reqwest")]
-impl Client for reqwest::Client {
-    type Error = reqwest::Error;
-
-    async fn request(
-        &self,
-        path: &str,
-        body: bytes::Bytes,
-        headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
-        let mut request = self.post(path);
-        for (k, v) in headers {
-            request = request.header(k, v);
-        }
-        let response = request.body(body).send().await;
-        let response = match response {
-            Ok(response) => response,
-            Err(e) => return Err(e),
-        };
-        let status = response.status();
-        let body = response.bytes().await;
-        let body = match body {
-            Ok(body) => body,
-            Err(e) => return Err(e),
-        };
-        Ok((status, body))
-    }
-}
-
-/* -----> */
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         pub health: HealthInterface<C>,
         pub pets: PetsInterface<C>,
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self {
                 health: HealthInterface::new(client.clone(), base_url.clone()),
@@ -167,12 +32,12 @@ pub mod interface {
     }
 
     #[derive(Debug)]
-    pub struct HealthInterface<C: super::Client + Clone> {
+    pub struct HealthInterface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> HealthInterface<C> {
+    impl<C: reflectapi::rt::Client + Clone> HealthInterface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -181,8 +46,8 @@ pub mod interface {
             &self,
             input: reflectapi::Empty,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
                 &self.client,
                 &self.base_url,
                 "/health.check",
@@ -194,12 +59,12 @@ pub mod interface {
     }
 
     #[derive(Debug)]
-    pub struct PetsInterface<C: super::Client + Clone> {
+    pub struct PetsInterface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> PetsInterface<C> {
+    impl<C: reflectapi::rt::Client + Clone> PetsInterface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -210,9 +75,16 @@ pub mod interface {
             headers: super::types::myapi::proto::Headers,
         ) -> Result<
             super::types::myapi::proto::Paginated<super::types::myapi::model::Pet>,
-            super::Error<super::types::myapi::proto::PetsListError, C::Error>,
+            reflectapi::rt::Error<super::types::myapi::proto::PetsListError, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/pets.list", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/pets.list",
+                input,
+                headers,
+            )
+            .await
         }
         /// Create a new pet
         pub async fn create(
@@ -221,10 +93,16 @@ pub mod interface {
             headers: super::types::myapi::proto::Headers,
         ) -> Result<
             reflectapi::Empty,
-            super::Error<super::types::myapi::proto::PetsCreateError, C::Error>,
+            reflectapi::rt::Error<super::types::myapi::proto::PetsCreateError, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/pets.create", input, headers)
-                .await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/pets.create",
+                input,
+                headers,
+            )
+            .await
         }
         /// Update an existing pet
         pub async fn update(
@@ -233,10 +111,16 @@ pub mod interface {
             headers: super::types::myapi::proto::Headers,
         ) -> Result<
             reflectapi::Empty,
-            super::Error<super::types::myapi::proto::PetsUpdateError, C::Error>,
+            reflectapi::rt::Error<super::types::myapi::proto::PetsUpdateError, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/pets.update", input, headers)
-                .await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/pets.update",
+                input,
+                headers,
+            )
+            .await
         }
         /// Remove an existing pet
         pub async fn remove(
@@ -245,10 +129,16 @@ pub mod interface {
             headers: super::types::myapi::proto::Headers,
         ) -> Result<
             reflectapi::Empty,
-            super::Error<super::types::myapi::proto::PetsRemoveError, C::Error>,
+            reflectapi::rt::Error<super::types::myapi::proto::PetsRemoveError, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/pets.remove", input, headers)
-                .await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/pets.remove",
+                input,
+                headers,
+            )
+            .await
         }
         /// Fetch first pet, if any exists
         pub async fn get_first(
@@ -257,9 +147,9 @@ pub mod interface {
             headers: super::types::myapi::proto::Headers,
         ) -> Result<
             std::option::Option<super::types::myapi::model::Pet>,
-            super::Error<super::types::myapi::proto::UnauthorizedError, C::Error>,
+            reflectapi::rt::Error<super::types::myapi::proto::UnauthorizedError, C::Error>,
         > {
-            super::__request_impl(
+            reflectapi::rt::__request_impl(
                 &self.client,
                 &self.base_url,
                 "/pets.get-first",
@@ -395,70 +285,3 @@ pub mod types {
         }
     }
 }
-/* <----- */
-
-async fn __request_impl<C, I, H, O, E>(
-    client: &C,
-    base_url: &str,
-    path: &str,
-    body: I,
-    headers: H,
-) -> Result<O, Error<E, C::Error>>
-where
-    C: Client,
-    I: serde::Serialize,
-    H: serde::Serialize,
-    O: serde::de::DeserializeOwned,
-    E: serde::de::DeserializeOwned,
-{
-    let body = serde_json::to_vec(&body).map_err(|e| Error::Protocol {
-        info: e.to_string(),
-        stage: ProtocolErrorStage::SerializeRequestBody,
-    })?;
-    let body = bytes::Bytes::from(body);
-    let headers = serde_json::to_value(&headers).map_err(|e| Error::Protocol {
-        info: e.to_string(),
-        stage: ProtocolErrorStage::SerializeRequestHeaders,
-    })?;
-
-    let mut headers_serialized = std::collections::HashMap::new();
-    match headers {
-        serde_json::Value::Object(headers) => {
-            for (k, v) in headers.into_iter() {
-                let v_str = match v {
-                    serde_json::Value::String(v) => v,
-                    v => v.to_string(),
-                };
-                headers_serialized.insert(k, v_str);
-            }
-        }
-        serde_json::Value::Null => {}
-        _ => {
-            return Err(Error::Protocol {
-                info: "Headers must be an object".to_string(),
-                stage: ProtocolErrorStage::SerializeRequestHeaders,
-            });
-        }
-    }
-    let (status, body) = client
-        .request(&format!("{}{}", base_url, path), body, headers_serialized)
-        .await
-        .map_err(Error::Network)?;
-    if status.is_success() {
-        let output = serde_json::from_slice(&body).map_err(|e| Error::Protocol {
-            info: e.to_string(),
-            stage: ProtocolErrorStage::DeserializeResponseBody(body),
-        })?;
-        return Ok(output);
-    }
-    match serde_json::from_slice::<E>(&body) {
-        Ok(error) => Err(Error::Application(error)),
-        Err(e) if status.is_client_error() => Err(Error::Protocol {
-            info: e.to_string(),
-            stage: ProtocolErrorStage::DeserializeResponseError(status, body),
-        }),
-        Err(_) => Err(Error::Server(status, body)),
-    }
-}
-
-/* -----> */

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_enum_documented-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_enum_documented-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestEnumDocumented<u8>>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::basic::TestEnumDocumented<u8>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_documented-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_documented-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestStructDocumented>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::basic::TestStructDocumented,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_empty-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_empty-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructEmpty>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructEmpty,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_newtype-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_newtype-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructNewtype>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructNewtype,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestStructOneBasicFieldString>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::basic::TestStructOneBasicFieldString,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructOneBasicFieldStringReflectBoth>()
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructOneBasicFieldStringReflectBoth,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally-3.snap
@@ -12,22 +12,30 @@ expression: "super::into_rust_code::<TestStructOneBasicFieldStringReflectBothEqu
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
     pub async fn inout_test(&self, input: super::types::reflectapi_demo::tests::basic::TestStructOneBasicFieldStringReflectBothEqually, headers: reflectapi::Empty)
-        -> Result<super::types::reflectapi_demo::tests::basic::TestStructOneBasicFieldStringReflectBothEqually, super::Error<reflectapi::Empty, C::Error>>{
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+        -> Result<super::types::reflectapi_demo::tests::basic::TestStructOneBasicFieldStringReflectBothEqually, reflectapi::rt::Error<reflectapi::Empty, C::Error>>{
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally2-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally2-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestStructOneBasicFieldStringReflectB
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::basic::TestStructOneBasicFieldStringReflectBothEqually,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_with_attributes-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_with_attributes-3.snap
@@ -12,22 +12,30 @@ expression: "super::into_rust_code::<TestStructOneBasicFieldStringReflectBothDif
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
     pub async fn inout_test(&self, input: super::types::reflectapi_demo::tests::basic::input::TestStructOneBasicFieldStringReflectBothDifferently, headers: reflectapi::Empty)
-        -> Result<super::types::reflectapi_demo::tests::basic::output::TestStructOneBasicFieldStringReflectBothDifferently, super::Error<reflectapi::Empty, C::Error>>{
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+        -> Result<super::types::reflectapi_demo::tests::basic::output::TestStructOneBasicFieldStringReflectBothDifferently, reflectapi::rt::Error<reflectapi::Empty, C::Error>>{
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_u32-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_u32-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestStructOneBasicFieldU32>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::basic::TestStructOneBasicFieldU32,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_option-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_option-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructOption>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructOption,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_tuple-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_tuple-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructTuple>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructTuple,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_unit_type-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_unit_type-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructUnitType>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructUnitType,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_all_primitive_type_fields-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_all_primitive_type_fields-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithAllPrimitiveTypeFields>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithAllPrimitiveTypeFields,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithArc>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithArc,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc_pointer_only-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc_pointer_only-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithArcPointerOnly>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithArcPointerOnly,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithAttributes>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithAttributes,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_input_only-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_input_only-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithAttributesInputOnly>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::output::TestStructWithAttributesInputOnly,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_output_only-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_output_only-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithAttributesOutputOnly>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::output::TestStructWithAttributesOutputOnly,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_type_only-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_type_only-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithAttributesTypeOnly>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithAttributesTypeOnly,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_fixed_size_array-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_fixed_size_array-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithFixedSizeArray>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithFixedSizeArray,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashmap-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashmap-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithHashMap>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithHashMap,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithHashSetField>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithHashSetField,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field_generic-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field_generic-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithHashSetFieldGeneric<String>>(
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -35,9 +36,16 @@ pub mod interface {
             super::types::reflectapi_demo::tests::basic::TestStructWithHashSetFieldGeneric<
                 std::string::String,
             >,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithNested>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithNested,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested_external-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested_external-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithNestedExternal>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithNestedExternal,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_self_via_arc-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_self_via_arc-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithSelfViaArc>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithSelfViaArc,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithSkipField>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithSkipField,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_input-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_input-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithSkipFieldInput>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::output::TestStructWithSkipFieldInput,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_output-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_output-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithSkipFieldOutput>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::output::TestStructWithSkipFieldOutput,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_array-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_array-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithTransformArray>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithTransformArray,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_both-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_both-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithTransformBoth>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithTransformBoth,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithTransformFallback>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithTransformFallback,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback_nested-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback_nested-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithTransformFallbackNested>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithTransformFallbackNested,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_input-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_input-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithTransformInput>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::output::TestStructWithTransformInput,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_output-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_output-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithTransformOutput>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::output::TestStructWithTransformOutput,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithTuple>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithTuple,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple12-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple12-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithTuple12>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithTuple12,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithVec>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithVec,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_external-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_external-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithVecExternal>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithVecExternal,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_nested-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_nested-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithVecNested>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithVecNested,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_two-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_two-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithVecTwo>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::basic::TestStructWithVecTwo,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestEnum>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnum,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_empty-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_empty-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestEnumEmpty>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnumEmpty,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_rename_num-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_rename_num-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<Nums>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::enums::Nums,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_basic_variant_and_fields_and_named_fields-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_basic_variant_and_fields_and_named_fields-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestEnumWithBasicVariantAndFieldsAndN
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnumWithBasicVariantAndFieldsAndNamedFields,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_ignored_input-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_ignored_input-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestEnumWithDiscriminantIgnored>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnumWithDiscriminantIgnored,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_ignored_output-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_ignored_output-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_output_rust_code::<TestEnumWithDiscriminantIgnored>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,10 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::enums::TestEnumWithDiscriminantIgnored,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/output_test", input, headers)
-                .await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/output_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_input-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_input-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestEnumWithDiscriminant>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnumWithDiscriminant,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_output-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_discriminant_output-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_output_rust_code::<TestEnumWithDiscriminant>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,10 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::enums::TestEnumWithDiscriminant,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/output_test", input, headers)
-                .await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/output_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_empty_variant_and_fields-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_empty_variant_and_fields-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestEnumWithEmptyVariantAndFields>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnumWithEmptyVariantAndFields,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_fields-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_fields-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestEnumWithFields>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnumWithFields,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestEnumWithGenerics<u8>>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnumWithGenerics<u8>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestEnumWithGenericsAndFields<u8>>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnumWithGenericsAndFields<u8>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields_and_named_fields-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields_and_named_fields-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestEnumWithGenericsAndFieldsAndNamed
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::enums::TestEnumWithGenericsAndFieldsAndNamedFields<u8>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestStructWithCircularReference>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithCircularReference,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestStructWithCircularReferenceGeneri
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGeneric<u8>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_parent-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_parent-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestStructWithCircularReferenceGeneri
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericParent<u8>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestStructWithCircularReferenceGeneri
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBox<super::types::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBox<u8, u16>, super::types::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBox<std::string::String, u32>>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestStructWithCircularReferenceGeneri
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBoxParent<super::types::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBoxParent<u8, u16>, super::types::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBoxParent<std::string::String, u32>>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent_specific-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent_specific-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestStructWithCircularReferenceGeneri
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithCircularReferenceGenericWithoutBoxParentSpecific,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestStructWithNestedGenericStruct>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithNestedGenericStruct,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct_twice-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct_twice-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestStructWithNestedGenericStructTwic
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithNestedGenericStructTwice,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_simple_generic-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_simple_generic-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestStructWithSimpleGeneric<u8>>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithSimpleGeneric<u8>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestStructWithVecGeneric<u8>>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithVecGeneric<u8>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestStructWithVecGenericGeneric<u8>>(
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,8 +32,15 @@ pub mod interface {
                 u8,
             >,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic_generic-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic_generic-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_input_rust_code::<TestStructWithVecGenericGenericGeneri
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -29,8 +30,15 @@ pub mod interface {
             &self,
             input: super::types::reflectapi_demo::tests::generics::TestStructWithVecGenericGenericGeneric<std::vec::Vec<u8>>,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(&self.client, &self.base_url, "/input_test", input, headers).await
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/input_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__namespace__namespace_with_dash-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__namespace__namespace_with_dash-3.snap
@@ -12,152 +12,18 @@ expression: rust
 #![allow(dead_code)]
 
 pub use interface::Interface;
-/* <----- */
-
-pub trait Client {
-    type Error;
-
-    fn request(
-        &self,
-        path: &str,
-        body: bytes::Bytes,
-        headers: std::collections::HashMap<String, String>,
-    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
-}
-
-pub enum Error<AE, NE> {
-    Application(AE),
-    Network(NE),
-    Protocol {
-        info: String,
-        stage: ProtocolErrorStage,
-    },
-    Server(http::StatusCode, bytes::Bytes),
-}
-
-impl<AE: core::fmt::Debug, NE: core::fmt::Debug> core::fmt::Debug for Error<AE, NE> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Error::Application(err) => write!(f, "Application error: {err:?}"),
-            Error::Network(err) => write!(f, "Network error: {err:?}"),
-            Error::Protocol { info, stage } => write!(f, "Protocol error: {info} at {stage:?}"),
-            Error::Server(status, body) => write!(
-                f,
-                "Server error: {status} with body: {}",
-                String::from_utf8_lossy(body)
-            ),
-        }
-    }
-}
-
-impl<AE: core::fmt::Display, NE: core::fmt::Display> core::fmt::Display for Error<AE, NE> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Error::Application(err) => write!(f, "Application error: {err}"),
-            Error::Network(err) => write!(f, "Network error: {err}"),
-            Error::Protocol { info, stage } => write!(f, "Protocol error: {info} at {stage}"),
-            Error::Server(status, body) => write!(
-                f,
-                "Server error: {status} with body: {}",
-                String::from_utf8_lossy(body)
-            ),
-        }
-    }
-}
-
-impl<AE: std::error::Error, NE: std::error::Error> std::error::Error for Error<AE, NE> {}
-
-pub enum ProtocolErrorStage {
-    SerializeRequestBody,
-    SerializeRequestHeaders,
-    DeserializeResponseBody(bytes::Bytes),
-    DeserializeResponseError(http::StatusCode, bytes::Bytes),
-}
-
-impl core::fmt::Display for ProtocolErrorStage {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            ProtocolErrorStage::SerializeRequestBody => {
-                write!(f, "failed to serialize request body")
-            }
-            ProtocolErrorStage::SerializeRequestHeaders => {
-                write!(f, "failed to serialize request headers")
-            }
-            ProtocolErrorStage::DeserializeResponseBody(body) => write!(
-                f,
-                "failed to deserialize response body: {}",
-                String::from_utf8_lossy(body)
-            ),
-            ProtocolErrorStage::DeserializeResponseError(status, body) => write!(
-                f,
-                "failed to deserialize response error: {} with body: {}",
-                status,
-                String::from_utf8_lossy(body)
-            ),
-        }
-    }
-}
-
-impl core::fmt::Debug for ProtocolErrorStage {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            ProtocolErrorStage::SerializeRequestBody => write!(f, "SerializeRequestBody"),
-            ProtocolErrorStage::SerializeRequestHeaders => write!(f, "SerializeRequestHeaders"),
-            ProtocolErrorStage::DeserializeResponseBody(body) => write!(
-                f,
-                "DeserializeResponseBody({:?})",
-                String::from_utf8_lossy(body)
-            ),
-            ProtocolErrorStage::DeserializeResponseError(status, body) => write!(
-                f,
-                "DeserializeResponseError({status}, {:?})",
-                String::from_utf8_lossy(body)
-            ),
-        }
-    }
-}
-
-#[cfg(feature = "reqwest")]
-impl Client for reqwest::Client {
-    type Error = reqwest::Error;
-
-    async fn request(
-        &self,
-        path: &str,
-        body: bytes::Bytes,
-        headers: std::collections::HashMap<String, String>,
-    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
-        let mut request = self.post(path);
-        for (k, v) in headers {
-            request = request.header(k, v);
-        }
-        let response = request.body(body).send().await;
-        let response = match response {
-            Ok(response) => response,
-            Err(e) => return Err(e),
-        };
-        let status = response.status();
-        let body = response.bytes().await;
-        let body = match body {
-            Ok(body) => body,
-            Err(e) => return Err(e),
-        };
-        Ok((status, body))
-    }
-}
-
-/* -----> */
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         pub jobs_two: JobsTwoInterface<C>,
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self {
                 jobs_two: JobsTwoInterface::new(client.clone(), base_url.clone()),
@@ -168,13 +34,13 @@ pub mod interface {
     }
 
     #[derive(Debug)]
-    pub struct JobsTwoInterface<C: super::Client + Clone> {
+    pub struct JobsTwoInterface<C: reflectapi::rt::Client + Clone> {
         pub pet_orders: JobsTwoPetOrdersInterface<C>,
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> JobsTwoInterface<C> {
+    impl<C: reflectapi::rt::Client + Clone> JobsTwoInterface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self {
                 pet_orders: JobsTwoPetOrdersInterface::new(client.clone(), base_url.clone()),
@@ -185,12 +51,12 @@ pub mod interface {
     }
 
     #[derive(Debug)]
-    pub struct JobsTwoPetOrdersInterface<C: super::Client + Clone> {
+    pub struct JobsTwoPetOrdersInterface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> JobsTwoPetOrdersInterface<C> {
+    impl<C: reflectapi::rt::Client + Clone> JobsTwoPetOrdersInterface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -199,8 +65,8 @@ pub mod interface {
             &self,
             input: reflectapi::Empty,
             headers: reflectapi::Empty,
-        ) -> Result<reflectapi::Empty, super::Error<reflectapi::Empty, C::Error>> {
-            super::__request_impl(
+        ) -> Result<reflectapi::Empty, reflectapi::rt::Error<reflectapi::Empty, C::Error>> {
+            reflectapi::rt::__request_impl(
                 &self.client,
                 &self.base_url,
                 "/jobs-two.pet-orders.list-x",
@@ -211,71 +77,3 @@ pub mod interface {
         }
     }
 }
-
-/* <----- */
-
-async fn __request_impl<C, I, H, O, E>(
-    client: &C,
-    base_url: &str,
-    path: &str,
-    body: I,
-    headers: H,
-) -> Result<O, Error<E, C::Error>>
-where
-    C: Client,
-    I: serde::Serialize,
-    H: serde::Serialize,
-    O: serde::de::DeserializeOwned,
-    E: serde::de::DeserializeOwned,
-{
-    let body = serde_json::to_vec(&body).map_err(|e| Error::Protocol {
-        info: e.to_string(),
-        stage: ProtocolErrorStage::SerializeRequestBody,
-    })?;
-    let body = bytes::Bytes::from(body);
-    let headers = serde_json::to_value(&headers).map_err(|e| Error::Protocol {
-        info: e.to_string(),
-        stage: ProtocolErrorStage::SerializeRequestHeaders,
-    })?;
-
-    let mut headers_serialized = std::collections::HashMap::new();
-    match headers {
-        serde_json::Value::Object(headers) => {
-            for (k, v) in headers.into_iter() {
-                let v_str = match v {
-                    serde_json::Value::String(v) => v,
-                    v => v.to_string(),
-                };
-                headers_serialized.insert(k, v_str);
-            }
-        }
-        serde_json::Value::Null => {}
-        _ => {
-            return Err(Error::Protocol {
-                info: "Headers must be an object".to_string(),
-                stage: ProtocolErrorStage::SerializeRequestHeaders,
-            });
-        }
-    }
-    let (status, body) = client
-        .request(&format!("{}{}", base_url, path), body, headers_serialized)
-        .await
-        .map_err(Error::Network)?;
-    if status.is_success() {
-        let output = serde_json::from_slice(&body).map_err(|e| Error::Protocol {
-            info: e.to_string(),
-            stage: ProtocolErrorStage::DeserializeResponseBody(body),
-        })?;
-        return Ok(output);
-    }
-    match serde_json::from_slice::<E>(&body) {
-        Ok(error) => Err(Error::Application(error)),
-        Err(e) if status.is_client_error() => Err(Error::Protocol {
-            info: e.to_string(),
-            stage: ProtocolErrorStage::DeserializeResponseError(status, body),
-        }),
-        Err(_) => Err(Error::Server(status, body)),
-    }
-}
-
-/* -----> */

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__adj_repr_enum_with_untagged_variant-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__adj_repr_enum_with_untagged_variant-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<Test>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::Test,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_adjacently_tagged-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_adjacently_tagged-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestEmptyVariantsAdjacentlyTagged>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEmptyVariantsAdjacentlyTagged,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_externally_tagged-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_externally_tagged-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestEmptyVariantsExternallyTagged>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEmptyVariantsExternallyTagged,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_internally_tagged-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_internally_tagged-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestEmptyVariantsInterallyTagged>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEmptyVariantsInterallyTagged,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_untagged-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_untagged-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestEmptyVariantsUntagged>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEmptyVariantsUntagged,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestEnumRename>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::MyEnum,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestEnumRenameAll>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumRenameAll,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all_on_variant-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all_on_variant-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestEnumRenameAllOnVariant>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumRenameAllOnVariant,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_variant_field-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_variant_field-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestEnumRenameVariantField>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumRenameVariantField,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestEnumTag>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumTag,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestEnumTagContent>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumTagContent,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content_rename_all-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content_rename_all-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestEnumTagContentRenameAll>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumTagContentRenameAll,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_untagged-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_untagged-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestEnumUntagged>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumUntagged,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_field_skip-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_field_skip-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestEnumWithFieldSkip>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumWithFieldSkip,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_rename_to_invalid_chars-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_rename_to_invalid_chars-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestEnumWithRenameToInvalidChars>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumWithRenameToInvalidChars,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_other-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_other-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestEnumWithVariantOther>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestEnumWithVariantOther,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestEnumWithVariantSkip>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumWithVariantSkip,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_deserialize-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_deserialize-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestEnumWithVariantSkipDeserialize>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestEnumWithVariantSkipDeserialize,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_serialize-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_skip_serialize-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestEnumWithVariantSkipSerialize>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestEnumWithVariantSkipSerialize,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_untagged-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_untagged-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestEnumWithVariantUntagged>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestEnumWithVariantUntagged,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__newtype_variants_internally_tagged-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__newtype_variants_internally_tagged-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<Enum>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::Enum,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_from-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_from-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructFromProxy>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestStructFromProxy,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_into-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_into-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructIntoProxy>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestStructIntoProxy,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructRename>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::MyStruct,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructRenameAll>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestStructRenameAll,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_differently-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_differently-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructRenameAllDifferently>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestStructRenameAllDifferently,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_pascal_case-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_pascal_case-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructRenameAllPascalCase>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestStructRenameAllPascalCase,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_differently-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_differently-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructRenameDifferently>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::MyStructOutput,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_field-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_field-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructRenameField>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestStructRenameField,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_try_from-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_try_from-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructTryFormProxy>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestStructTryFormProxy,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithFlatten>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestStructWithFlatten,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithFlattenOptional>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestStructWithFlattenOptional,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional_and_required-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional_and_required-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithFlattenOptionalAndRequired>()
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestStructWithFlattenOptionalAndRequired,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_invalid_chars-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_invalid_chars-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithRenameToInvalidChars>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestStructWithRenameToInvalidChars,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_kebab_case-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_kebab_case-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithRenameToKebabCase>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::struct_name,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_default-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_default-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithSerdeDefault>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestStructWithSerdeDefault,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithSerdeSkip>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestStructWithSerdeSkip,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_deserialize-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_deserialize-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithSerdeSkipDeserialize>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestStructWithSerdeSkipDeserialize,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithSerdeSkipSerialize>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestStructWithSerdeSkipSerialize,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize_if-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize_if-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithSerdeSkipSerializeIf>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::output::TestStructWithSerdeSkipSerializeIf,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_transparent-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_transparent-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestStructWithSerdeTransparent>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestStructWithSerdeTransparent,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__unit_struct-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__unit_struct-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestUnitStruct>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestUnitStruct,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__unit_tuple_struct-3.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__unit_tuple_struct-3.snap
@@ -12,16 +12,17 @@ expression: "super::into_rust_code::<TestUnitTupleStruct>()"
 #![allow(dead_code)]
 
 pub use interface::Interface;
+pub use reflectapi::rt::*;
 
 pub mod interface {
 
     #[derive(Debug)]
-    pub struct Interface<C: super::Client + Clone> {
+    pub struct Interface<C: reflectapi::rt::Client + Clone> {
         client: C,
         base_url: std::string::String,
     }
 
-    impl<C: super::Client + Clone> Interface<C> {
+    impl<C: reflectapi::rt::Client + Clone> Interface<C> {
         pub fn new(client: C, base_url: std::string::String) -> Self {
             Self { client, base_url }
         }
@@ -31,9 +32,16 @@ pub mod interface {
             headers: reflectapi::Empty,
         ) -> Result<
             super::types::reflectapi_demo::tests::serde::TestUnitTupleStruct,
-            super::Error<reflectapi::Empty, C::Error>,
+            reflectapi::rt::Error<reflectapi::Empty, C::Error>,
         > {
-            super::__request_impl(&self.client, &self.base_url, "/inout_test", input, headers).await
+            reflectapi::rt::__request_impl(
+                &self.client,
+                &self.base_url,
+                "/inout_test",
+                input,
+                headers,
+            )
+            .await
         }
     }
 }

--- a/reflectapi/Cargo.toml
+++ b/reflectapi/Cargo.toml
@@ -64,7 +64,7 @@ url = ["dep:url"]
 rust_decimal = ["dep:rust_decimal"]
 # features for transforming reflect schema to runnable servers
 # based on dififerent web server frameworks
-axum = ["dep:axum"]
+axum = ["dep:axum", "builder"]
 # feature flag for enabling codegen libraries
 codegen = ["dep:askama", "dep:anyhow", "dep:indexmap", "dep:check_keyword", "dep:serde_json"]
 rt = []

--- a/reflectapi/Cargo.toml
+++ b/reflectapi/Cargo.toml
@@ -47,7 +47,7 @@ anyhow = { version = "1.0.81", optional = true }
 indexmap = { version = "2.2.6", optional = true }
 check_keyword = { version = "0.2.0", optional = true }
 
-# optional 3rd party dependencies for runtime
+# optional 3rd party dependencies for client runtime
 reqwest = { version = "0.12", optional = true }
 
 [dev-dependencies]
@@ -55,7 +55,7 @@ serde_json = { version = "1.0.114" }
 
 [features]
 # feature for implementing schema builder
-builder = ["dep:serde_json", "dep:bytes", "http"]
+builder = ["dep:serde_json", "dep:bytes", "dep:http"]
 msgpack = ["dep:rmp-serde", "builder"]
 # features for implementing reflect traits for foreigh types
 uuid = ["dep:uuid"]
@@ -67,4 +67,4 @@ rust_decimal = ["dep:rust_decimal"]
 axum = ["dep:axum", "builder"]
 # feature flag for enabling codegen libraries
 codegen = ["dep:askama", "dep:anyhow", "dep:indexmap", "dep:check_keyword", "dep:serde_json"]
-rt = []
+rt = ["dep:http", "dep:serde_json", "dep:bytes"]

--- a/reflectapi/Cargo.toml
+++ b/reflectapi/Cargo.toml
@@ -31,7 +31,7 @@ http = { version = "1.1.0", optional = true }
 # optional 3rd party dependencies for additional serialization formats
 rmp-serde = {version = "1.3.0", optional = true }
 
-# optional 3rd party dependencies for implementing reflects traits for foreigh types
+# optional 3rd party dependencies for implementing reflects traits for foreign types
 uuid = { version = "1.7.0", optional = true }
 chrono = { version = "0.4.37", optional = true }
 url = { version = "2.5.0", optional = true }
@@ -46,6 +46,9 @@ askama = { version = "0.12.1", optional = true }
 anyhow = { version = "1.0.81", optional = true }
 indexmap = { version = "2.2.6", optional = true }
 check_keyword = { version = "0.2.0", optional = true }
+
+# optional 3rd party dependencies for runtime
+reqwest = { version = "0.12", optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1.0.114" }
@@ -64,3 +67,4 @@ rust_decimal = ["dep:rust_decimal"]
 axum = ["dep:axum"]
 # feature flag for enabling codegen libraries
 codegen = ["dep:askama", "dep:anyhow", "dep:indexmap", "dep:check_keyword", "dep:serde_json"]
+rt = []

--- a/reflectapi/src/codegen/rust-dependency-stubs/Makefile
+++ b/reflectapi/src/codegen/rust-dependency-stubs/Makefile
@@ -2,13 +2,22 @@ RUSTC = rustc
 
 .PHONY: check deps clean
 
-check: deps generated.rs
-	$(RUSTC) --edition 2021 --crate-type=lib --emit=mir=/dev/null -L . --extern serde=libserde.rlib --extern serde_json=libserde_json.rlib --extern bytes=libbytes.rlib --extern http=libhttp.rlib --extern reflectapi=libreflectapi.rlib generated.rs
-
-deps: libserde.rlib libserde_json.rlib libbytes.rlib libhttp.rlib libreflectapi.rlib
+check: libreflectapi.rlib libserde.rlib generated.rs
+	$(RUSTC) --edition 2021 --crate-type=lib --emit=mir=/dev/null -L . \
+		--extern reflectapi=libreflectapi.rlib \
+		--extern serde=libserde.rlib \
+		generated.rs
 
 clean:
 	rm -f *.rlib *.rmeta *.so
+
+libreflectapi.rlib: libserde.rlib libserde_json.rlib libbytes.rlib libhttp.rlib
+	$(RUSTC) --edition 2021 --crate-type=rlib --crate-name=reflectapi --emit=metadata,link -L . \
+		--extern serde=libserde.rlib \
+		--extern serde_json=libserde_json.rlib \
+		--extern bytes=libbytes.rlib \
+		--extern http=libhttp.rlib \
+		reflectapi.rs
 
 libserde.rlib: libserde_derive.rmeta libserde_derive.so
 	$(RUSTC) --edition 2021 --crate-type=rlib --crate-name=serde --emit=metadata,link -L . --extern serde_derive=libserde_derive.rmeta --extern serde_derive=libserde_derive.so serde.rs

--- a/reflectapi/src/codegen/rust-dependency-stubs/reflectapi.rs
+++ b/reflectapi/src/codegen/rust-dependency-stubs/reflectapi.rs
@@ -3,3 +3,5 @@ pub struct Empty {}
 
 #[derive(Debug)]
 pub struct Infallible {}
+
+pub mod rt;

--- a/reflectapi/src/codegen/rust-dependency-stubs/reqwest.rs
+++ b/reflectapi/src/codegen/rust-dependency-stubs/reqwest.rs
@@ -1,0 +1,9 @@
+#[derive(Debug)]
+pub struct Error {}
+
+#[derive(Debug, Clone)]
+pub struct Client {}
+
+impl Client {
+    pub fn post(&self,)
+}

--- a/reflectapi/src/infallible.rs
+++ b/reflectapi/src/infallible.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "builder", feature = "axum"))]
+#[cfg(feature = "builder")]
 use crate::StatusCode;
 
 #[derive(serde::Deserialize, serde::Serialize)]
@@ -6,7 +6,7 @@ pub struct Infallible {
     marker: std::marker::PhantomData<()>,
 }
 
-#[cfg(any(feature = "builder", feature = "axum"))]
+#[cfg(feature = "builder")]
 impl StatusCode for Infallible {
     fn status_code(&self) -> http::StatusCode {
         http::StatusCode::INTERNAL_SERVER_ERROR

--- a/reflectapi/src/lib.rs
+++ b/reflectapi/src/lib.rs
@@ -5,6 +5,12 @@ mod option;
 mod traits;
 mod validation;
 
+#[cfg(feature = "rt")]
+pub mod rt;
+
+#[cfg(any(feature = "builder", feature = "axum"))]
+pub use builder::*;
+
 #[cfg(any(feature = "builder", feature = "axum"))]
 mod builder;
 
@@ -18,9 +24,6 @@ pub use empty::*;
 #[allow(unused_imports)]
 pub use impls::*;
 pub use infallible::*;
-
-#[cfg(any(feature = "builder", feature = "axum"))]
-pub use builder::*;
 
 pub use option::*;
 pub use reflectapi_derive::*;

--- a/reflectapi/src/lib.rs
+++ b/reflectapi/src/lib.rs
@@ -8,10 +8,10 @@ mod validation;
 #[cfg(feature = "rt")]
 pub mod rt;
 
-#[cfg(any(feature = "builder", feature = "axum"))]
+#[cfg(any(feature = "builder"))]
 pub use builder::*;
 
-#[cfg(any(feature = "builder", feature = "axum"))]
+#[cfg(any(feature = "builder"))]
 mod builder;
 
 #[cfg(feature = "axum")]

--- a/reflectapi/src/lib.rs
+++ b/reflectapi/src/lib.rs
@@ -8,10 +8,10 @@ mod validation;
 #[cfg(feature = "rt")]
 pub mod rt;
 
-#[cfg(any(feature = "builder"))]
+#[cfg(feature = "builder")]
 pub use builder::*;
 
-#[cfg(any(feature = "builder"))]
+#[cfg(feature = "builder")]
 mod builder;
 
 #[cfg(feature = "axum")]

--- a/reflectapi/src/rt.rs
+++ b/reflectapi/src/rt.rs
@@ -1,0 +1,198 @@
+use std::collections::HashMap;
+
+pub trait Client {
+    type Error;
+
+    fn request(
+        &self,
+        path: &str,
+        body: bytes::Bytes,
+        headers: HashMap<String, String>,
+    ) -> impl std::future::Future<Output = Result<(http::StatusCode, bytes::Bytes), Self::Error>>;
+}
+
+pub enum Error<AE, NE> {
+    Application(AE),
+    Network(NE),
+    Protocol {
+        info: String,
+        stage: ProtocolErrorStage,
+    },
+    Server(http::StatusCode, bytes::Bytes),
+}
+
+impl<AE: core::fmt::Debug, NE: core::fmt::Debug> core::fmt::Debug for Error<AE, NE> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Error::Application(err) => write!(f, "Application error: {err:?}"),
+            Error::Network(err) => write!(f, "Network error: {err:?}"),
+            Error::Protocol { info, stage } => write!(f, "Protocol error: {info} at {stage:?}"),
+            Error::Server(status, body) => write!(
+                f,
+                "Server error: {status} with body: {}",
+                String::from_utf8_lossy(body)
+            ),
+        }
+    }
+}
+
+impl<AE: core::fmt::Display, NE: core::fmt::Display> core::fmt::Display for Error<AE, NE> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Error::Application(err) => write!(f, "Application error: {err}"),
+            Error::Network(err) => write!(f, "Network error: {err}"),
+            Error::Protocol { info, stage } => write!(f, "Protocol error: {info} at {stage}"),
+            Error::Server(status, body) => write!(
+                f,
+                "Server error: {status} with body: {}",
+                String::from_utf8_lossy(body)
+            ),
+        }
+    }
+}
+
+impl<AE: std::error::Error, NE: std::error::Error> std::error::Error for Error<AE, NE> {}
+
+pub enum ProtocolErrorStage {
+    SerializeRequestBody,
+    SerializeRequestHeaders,
+    DeserializeResponseBody(bytes::Bytes),
+    DeserializeResponseError(http::StatusCode, bytes::Bytes),
+}
+
+impl core::fmt::Display for ProtocolErrorStage {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ProtocolErrorStage::SerializeRequestBody => {
+                write!(f, "failed to serialize request body")
+            }
+            ProtocolErrorStage::SerializeRequestHeaders => {
+                write!(f, "failed to serialize request headers")
+            }
+            ProtocolErrorStage::DeserializeResponseBody(body) => write!(
+                f,
+                "failed to deserialize response body: {}",
+                String::from_utf8_lossy(body)
+            ),
+            ProtocolErrorStage::DeserializeResponseError(status, body) => write!(
+                f,
+                "failed to deserialize response error: {} with body: {}",
+                status,
+                String::from_utf8_lossy(body)
+            ),
+        }
+    }
+}
+
+impl core::fmt::Debug for ProtocolErrorStage {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ProtocolErrorStage::SerializeRequestBody => write!(f, "SerializeRequestBody"),
+            ProtocolErrorStage::SerializeRequestHeaders => write!(f, "SerializeRequestHeaders"),
+            ProtocolErrorStage::DeserializeResponseBody(body) => write!(
+                f,
+                "DeserializeResponseBody({:?})",
+                String::from_utf8_lossy(body)
+            ),
+            ProtocolErrorStage::DeserializeResponseError(status, body) => write!(
+                f,
+                "DeserializeResponseError({status}, {:?})",
+                String::from_utf8_lossy(body)
+            ),
+        }
+    }
+}
+
+#[doc(hidden)]
+pub async fn __request_impl<C, I, H, O, E>(
+    client: &C,
+    base_url: &str,
+    path: &str,
+    body: I,
+    headers: H,
+) -> Result<O, Error<E, C::Error>>
+where
+    C: Client,
+    I: serde::Serialize,
+    H: serde::Serialize,
+    O: serde::de::DeserializeOwned,
+    E: serde::de::DeserializeOwned,
+{
+    let body = serde_json::to_vec(&body).map_err(|e| Error::Protocol {
+        info: e.to_string(),
+        stage: ProtocolErrorStage::SerializeRequestBody,
+    })?;
+    let body = bytes::Bytes::from(body);
+    let headers = serde_json::to_value(&headers).map_err(|e| Error::Protocol {
+        info: e.to_string(),
+        stage: ProtocolErrorStage::SerializeRequestHeaders,
+    })?;
+
+    let mut headers_serialized = std::collections::HashMap::new();
+    match headers {
+        serde_json::Value::Object(headers) => {
+            for (k, v) in headers.into_iter() {
+                let v_str = match v {
+                    serde_json::Value::String(v) => v,
+                    v => v.to_string(),
+                };
+                headers_serialized.insert(k, v_str);
+            }
+        }
+        serde_json::Value::Null => {}
+        _ => {
+            return Err(Error::Protocol {
+                info: "Headers must be an object".to_string(),
+                stage: ProtocolErrorStage::SerializeRequestHeaders,
+            });
+        }
+    }
+    let (status, body) = client
+        .request(&format!("{}{}", base_url, path), body, headers_serialized)
+        .await
+        .map_err(Error::Network)?;
+    if status.is_success() {
+        let output = serde_json::from_slice(&body).map_err(|e| Error::Protocol {
+            info: e.to_string(),
+            stage: ProtocolErrorStage::DeserializeResponseBody(body),
+        })?;
+        return Ok(output);
+    }
+    match serde_json::from_slice::<E>(&body) {
+        Ok(error) => Err(Error::Application(error)),
+        Err(e) if status.is_client_error() => Err(Error::Protocol {
+            info: e.to_string(),
+            stage: ProtocolErrorStage::DeserializeResponseError(status, body),
+        }),
+        Err(_) => Err(Error::Server(status, body)),
+    }
+}
+
+#[cfg(feature = "reqwest")]
+impl Client for reqwest::Client {
+    type Error = reqwest::Error;
+
+    async fn request(
+        &self,
+        path: &str,
+        body: bytes::Bytes,
+        headers: std::collections::HashMap<String, String>,
+    ) -> Result<(http::StatusCode, bytes::Bytes), Self::Error> {
+        let mut request = self.post(path);
+        for (k, v) in headers {
+            request = request.header(k, v);
+        }
+        let response = request.body(body).send().await;
+        let response = match response {
+            Ok(response) => response,
+            Err(e) => return Err(e),
+        };
+        let status = response.status();
+        let body = response.bytes().await;
+        let body = match body {
+            Ok(body) => body,
+            Err(e) => return Err(e),
+        };
+        Ok((status, body))
+    }
+}


### PR DESCRIPTION
Instead of inlining all helper code into the generated file. Move to a separate runtime dependency crate named `reflectapi-rt`.

This has a few benefits:
- Much, much easier to modify runtime code as it's just a usual rust file rather than within some string.
-  Easier for generated clients to use as it groups all the runtime dependencies into one crate.