### PR TITLE
Glob rename of type's modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,6 +1547,7 @@ dependencies = [
 name = "reflectapi-schema"
 version = "0.6.6"
 dependencies = [
+ "glob",
  "serde",
 ]
 

--- a/reflectapi-demo/reflectapi.json
+++ b/reflectapi-demo/reflectapi.json
@@ -385,7 +385,7 @@
             "name": "T"
           }
         ],
-        "representation": "None",
+        "representation": "none",
         "variants": [
           {
             "name": "Undefined",
@@ -422,7 +422,7 @@
             "name": "T"
           }
         ],
-        "representation": "None",
+        "representation": "none",
         "variants": [
           {
             "name": "None",
@@ -736,7 +736,7 @@
             "name": "T"
           }
         ],
-        "representation": "None",
+        "representation": "none",
         "variants": [
           {
             "name": "None",

--- a/reflectapi-demo/src/lib.rs
+++ b/reflectapi-demo/src/lib.rs
@@ -37,7 +37,7 @@ pub fn builder() -> reflectapi::Builder<Arc<AppState>> {
         })
         // some optional tuning
         .fold_transparent_types()
-        .rename_type("reflectapi_demo::", "myapi::")
+        .rename_types("reflectapi_demo::", "myapi::")
         // and some optional linting rules
         .validate(|schema| {
             let mut errors = Vec::new();

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_option.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_option.snap
@@ -56,7 +56,7 @@ expression: schema
             "name": "T"
           }
         ],
-        "representation": "None",
+        "representation": "none",
         "variants": [
           {
             "name": "None",
@@ -123,7 +123,7 @@ expression: schema
             "name": "T"
           }
         ],
-        "representation": "None",
+        "representation": "none",
         "variants": [
           {
             "name": "None",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_all_primitive_type_fields.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_all_primitive_type_fields.snap
@@ -829,7 +829,7 @@ expression: schema
             "name": "T"
           }
         ],
-        "representation": "None",
+        "representation": "none",
         "variants": [
           {
             "name": "None",
@@ -2071,7 +2071,7 @@ expression: schema
             "name": "T"
           }
         ],
-        "representation": "None",
+        "representation": "none",
         "variants": [
           {
             "name": "None",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__adj_repr_enum_with_untagged_variant.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__adj_repr_enum_with_untagged_variant.snap
@@ -31,7 +31,7 @@ expression: schema
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::Test",
         "representation": {
-          "Internal": {
+          "internal": {
             "tag": "type"
           }
         },
@@ -91,7 +91,7 @@ expression: schema
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::Test",
         "representation": {
-          "Internal": {
+          "internal": {
             "tag": "type"
           }
         },

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_adjacently_tagged.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_adjacently_tagged.snap
@@ -31,7 +31,7 @@ expression: schema
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::TestEmptyVariantsAdjacentlyTagged",
         "representation": {
-          "Adjacent": {
+          "adjacent": {
             "tag": "t",
             "content": "c"
           }
@@ -69,7 +69,7 @@ expression: schema
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::TestEmptyVariantsAdjacentlyTagged",
         "representation": {
-          "Adjacent": {
+          "adjacent": {
             "tag": "t",
             "content": "c"
           }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_internally_tagged.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_internally_tagged.snap
@@ -31,7 +31,7 @@ expression: schema
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::TestEmptyVariantsInterallyTagged",
         "representation": {
-          "Internal": {
+          "internal": {
             "tag": "type"
           }
         },
@@ -62,7 +62,7 @@ expression: schema
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::TestEmptyVariantsInterallyTagged",
         "representation": {
-          "Internal": {
+          "internal": {
             "tag": "type"
           }
         },

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_untagged.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_untagged.snap
@@ -30,7 +30,7 @@ expression: schema
       {
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::TestEmptyVariantsUntagged",
-        "representation": "None",
+        "representation": "none",
         "variants": [
           {
             "name": "Empty",
@@ -63,7 +63,7 @@ expression: schema
       {
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::TestEmptyVariantsUntagged",
-        "representation": "None",
+        "representation": "none",
         "variants": [
           {
             "name": "Empty",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag.snap
@@ -31,7 +31,7 @@ expression: schema
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::TestEnumTag",
         "representation": {
-          "Internal": {
+          "internal": {
             "tag": "type"
           }
         },
@@ -85,7 +85,7 @@ expression: schema
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::TestEnumTag",
         "representation": {
-          "Internal": {
+          "internal": {
             "tag": "type"
           }
         },

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content.snap
@@ -31,7 +31,7 @@ expression: schema
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::TestEnumTagContent",
         "representation": {
-          "Adjacent": {
+          "adjacent": {
             "tag": "type",
             "content": "content"
           }
@@ -86,7 +86,7 @@ expression: schema
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::TestEnumTagContent",
         "representation": {
-          "Adjacent": {
+          "adjacent": {
             "tag": "type",
             "content": "content"
           }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content_rename_all.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content_rename_all.snap
@@ -31,7 +31,7 @@ expression: schema
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::TestEnumTagContentRenameAll",
         "representation": {
-          "Adjacent": {
+          "adjacent": {
             "tag": "type",
             "content": "content"
           }
@@ -86,7 +86,7 @@ expression: schema
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::TestEnumTagContentRenameAll",
         "representation": {
-          "Adjacent": {
+          "adjacent": {
             "tag": "type",
             "content": "content"
           }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_untagged.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_untagged.snap
@@ -30,7 +30,7 @@ expression: schema
       {
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::TestEnumUntagged",
-        "representation": "None",
+        "representation": "none",
         "variants": [
           {
             "name": "Variant1",
@@ -80,7 +80,7 @@ expression: schema
       {
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::TestEnumUntagged",
-        "representation": "None",
+        "representation": "none",
         "variants": [
           {
             "name": "Variant1",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_other.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_other.snap
@@ -31,7 +31,7 @@ expression: schema
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::TestEnumWithVariantOther",
         "representation": {
-          "Internal": {
+          "internal": {
             "tag": "type"
           }
         },
@@ -56,7 +56,7 @@ expression: schema
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::TestEnumWithVariantOther",
         "representation": {
-          "Internal": {
+          "internal": {
             "tag": "type"
           }
         },

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__newtype_variants_internally_tagged.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__newtype_variants_internally_tagged.snap
@@ -31,7 +31,7 @@ expression: schema
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::Enum",
         "representation": {
-          "Internal": {
+          "internal": {
             "tag": "type"
           }
         },
@@ -144,7 +144,7 @@ expression: schema
         "kind": "enum",
         "name": "reflectapi_demo::tests::serde::Enum",
         "representation": {
-          "Internal": {
+          "internal": {
             "tag": "type"
           }
         },

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional.snap
@@ -71,7 +71,7 @@ expression: schema
             "name": "T"
           }
         ],
-        "representation": "None",
+        "representation": "none",
         "variants": [
           {
             "name": "None",
@@ -153,7 +153,7 @@ expression: schema
             "name": "T"
           }
         ],
-        "representation": "None",
+        "representation": "none",
         "variants": [
           {
             "name": "None",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional_and_required.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional_and_required.snap
@@ -94,7 +94,7 @@ expression: schema
             "name": "T"
           }
         ],
-        "representation": "None",
+        "representation": "none",
         "variants": [
           {
             "name": "None",
@@ -199,7 +199,7 @@ expression: schema
             "name": "T"
           }
         ],
-        "representation": "None",
+        "representation": "none",
         "variants": [
           {
             "name": "None",

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize_if.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize_if.snap
@@ -56,7 +56,7 @@ expression: schema
             "name": "T"
           }
         ],
-        "representation": "None",
+        "representation": "none",
         "variants": [
           {
             "name": "None",
@@ -122,7 +122,7 @@ expression: schema
             "name": "T"
           }
         ],
-        "representation": "None",
+        "representation": "none",
         "variants": [
           {
             "name": "None",

--- a/reflectapi-schema/Cargo.toml
+++ b/reflectapi-schema/Cargo.toml
@@ -21,4 +21,8 @@ categories = ["web-programming", "development-tools", "api-bindings"]
 
 [dependencies]
 serde = { version = "1.0.197", features = ["derive"] }
+glob = { version = "0.3.0", optional = true }
+
+[features]
+default = ["glob"]
 

--- a/reflectapi-schema/src/rename.rs
+++ b/reflectapi-schema/src/rename.rs
@@ -1,0 +1,154 @@
+#[cfg(feature = "glob")]
+pub use self::glob::Glob;
+
+#[allow(private_bounds)]
+pub trait Pattern: Sealed + Copy {
+    fn rename(self, name: &str, with: &str) -> Option<String>;
+}
+
+impl Sealed for &str {}
+
+impl Pattern for &str {
+    fn rename(self, name: &str, replacer: &str) -> Option<String> {
+        if self.ends_with("::") {
+            // replacing module name
+            if let Some(name) = name.strip_prefix(self) {
+                let replacer = replacer.trim_end_matches("::");
+                if replacer.is_empty() {
+                    return Some(name.into());
+                }
+
+                Some(format!("{replacer}::{name}"))
+            } else {
+                None
+            }
+        } else {
+            // replacing type name
+            if name == self {
+                Some(replacer.into())
+            } else {
+                None
+            }
+        }
+    }
+}
+
+#[cfg(feature = "glob")]
+mod glob {
+    use core::fmt;
+    use std::str::FromStr;
+
+    use super::{Pattern, Sealed};
+
+    /// Bulk renamer of modules using glob patterns.
+    #[derive(Clone)]
+    pub struct Glob(glob::Pattern);
+
+    impl fmt::Debug for Glob {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}", self.0.to_string().replace('/', "::"))
+        }
+    }
+
+    impl FromStr for Glob {
+        type Err = glob::PatternError;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            let s = s.replace("::", "/");
+            Ok(Self(glob::Pattern::new(&s)?))
+        }
+    }
+
+    impl Sealed for &Glob {}
+
+    impl Pattern for &Glob {
+        fn rename(self, name: &str, replacer: &str) -> Option<String> {
+            let path = std::path::PathBuf::from(name.replace("::", "/"));
+            let file_name = path.file_name().expect("non-empty name");
+
+            if path.components().count() <= 1 {
+                // This means the `name` has no module, so we don't replace it.
+                return None;
+            }
+
+            if self.0.matches_path_with(
+                &path,
+                glob::MatchOptions {
+                    case_sensitive: true,
+                    require_literal_separator: true,
+                    require_literal_leading_dot: false,
+                },
+            ) {
+                let replacer = replacer.trim_end_matches("::");
+                let name = file_name
+                    .to_str()
+                    .expect("is utf-8 as it was converted from str");
+                if replacer.is_empty() {
+                    return Some(name.into());
+                }
+
+                Some(format!("{replacer}::{name}"))
+            } else {
+                None
+            }
+        }
+    }
+}
+
+trait Sealed {}
+
+#[cfg(test)]
+mod tests {
+    use super::Pattern;
+
+    #[track_caller]
+    fn check(matcher: impl Pattern, name: &str, replacer: &str, expected: Option<&str>) {
+        assert_eq!(matcher.rename(name, replacer).as_deref(), expected);
+    }
+
+    // Confusing to read if calling function directly
+    macro_rules! rename {
+        ($matcher:literal to $replacer:literal on $name:expr => $expected:expr) => {
+            check($matcher, $name, $replacer, $expected);
+        };
+    }
+
+    macro_rules! glob_rename {
+        ($matcher:literal to $replacer:literal on $name:expr => $expected:expr) => {
+            #[cfg(feature = "glob")]
+            check(
+                &$matcher.parse::<super::Glob>().unwrap(),
+                $name,
+                $replacer,
+                $expected,
+            );
+        };
+    }
+
+    #[test]
+    fn rename_str() {
+        rename!("foo" to "bar" on "foo" => Some("bar"));
+        rename!("foo" to "bar" on "baz" => None);
+
+        rename!("foo::" to "" on "foo::bar" => Some("bar"));
+
+        rename!("foo::" to "bar::" on "foo::a" => Some("bar::a"));
+        // Optional trailing `::` on replacer
+        rename!("foo::" to "bar" on "foo::a" => Some("bar::a"));
+    }
+
+    #[test]
+    fn rename_glob() {
+        // globs should only match modules
+        glob_rename!("foo*" to "bar" on "foo" => None);
+        glob_rename!("foo::*" to "bar::" on "foo::a" => Some("bar::a"));
+        // Optional trailing `::` on replacer
+        glob_rename!("foo::*" to "bar" on "foo::a" => Some("bar::a"));
+        glob_rename!("foo::*" to "" on "foo::a" => Some("a"));
+        glob_rename!("foo::*" to "bar" on "foo::a" => Some("bar::a"));
+        glob_rename!("foo::**" to "bar" on "foo::a::b::c" => Some("bar::c"));
+
+        // Must be a full match
+        glob_rename!("fo*" to "bar" on "foo::a" => None);
+    }
+}

--- a/reflectapi/Cargo.toml
+++ b/reflectapi/Cargo.toml
@@ -54,6 +54,7 @@ reqwest = { version = "0.12", optional = true }
 serde_json = { version = "1.0.114" }
 
 [features]
+default = ["glob"]
 # feature for implementing schema builder
 builder = ["dep:serde_json", "dep:bytes", "dep:http"]
 msgpack = ["dep:rmp-serde", "builder"]
@@ -68,3 +69,4 @@ axum = ["dep:axum", "builder"]
 # feature flag for enabling codegen libraries
 codegen = ["dep:askama", "dep:anyhow", "dep:indexmap", "dep:check_keyword", "dep:serde_json"]
 rt = ["dep:http", "dep:serde_json", "dep:bytes", "dep:url"]
+glob = ["reflectapi-schema/glob"]

--- a/reflectapi/src/builder/mod.rs
+++ b/reflectapi/src/builder/mod.rs
@@ -1,7 +1,10 @@
 mod handler;
 mod result;
 
+use core::fmt;
+
 pub use handler::*;
+use reflectapi_schema::Pattern;
 pub use result::*;
 
 #[derive(Debug)]
@@ -110,8 +113,19 @@ where
         self
     }
 
-    pub fn rename_type(mut self, from: &str, to: &str) -> Self {
-        self.schema.rename_type(from, to);
+    #[cfg(feature = "glob")]
+    pub fn glob_rename_types(self, glob: &str, replacer: &str) -> Self {
+        let matcher = glob
+            .parse::<reflectapi_schema::Glob>()
+            .unwrap_or_else(|err| panic!("invalid glob pattern: {err}"));
+        self.rename_types(&matcher, replacer)
+    }
+
+    #[track_caller]
+    pub fn rename_types(mut self, pattern: impl Pattern + fmt::Debug, to: &str) -> Self {
+        if self.schema.rename_types(pattern, to) == 0 {
+            panic!("no types matched the pattern: {pattern:?}");
+        }
         self
     }
 

--- a/reflectapi/src/codegen/typescript.rs
+++ b/reflectapi/src/codegen/typescript.rs
@@ -112,7 +112,7 @@ pub fn generate(mut schema: crate::Schema, config: &Config) -> anyhow::Result<St
                     "--stdin-file-path",
                     "dummy.ts",
                 ]),
-                Command::new("prettier").args(["--parser", "typescript"]),
+                Command::new("prettier").args(["--parser", "typescript", "--use-tabs"]),
             ],
             generated_code,
         )?;


### PR DESCRIPTION
Please suggest any more tests, I'm not entirely sure what the semantics of this should be. @avkonst .

The existing implementation has some issues i.e. `.rename_type("core_server_upload::upload_entity_issue::", "upload::")`
But in `reflectapi.json`. `upload::upload_entity_issue::UploadEntityIssue` still appears.

I've checked this against some internal code, the following diff doesn't change anything generated which is good.

```
diff --git a/packages/backend/apps/core-server/libs/upload/src/lib.rs b/packages/backend/apps/core-server/libs/upload/src/lib.rs
index 5eabcddc9f..4ca1d399b0 100644
--- a/packages/backend/apps/core-server/libs/upload/src/lib.rs
+++ b/packages/backend/apps/core-server/libs/upload/src/lib.rs
@@ -31,41 +31,14 @@ where
             b.name("uploads.issues.list".into())
                 .description("Paginated list of all issues in specific file".into())
         })
-        .rename_type("ingest_model::sellable_grouping::", "ingest::")
-            .rename_type("ingest_model::ingest_request::", "ingest::")
-            .rename_type("ingest_model::sellable::", "ingest::")
-            .rename_type("ingest_model::gapc_brand::", "ingest::")
-            .rename_type("ingest_model::gapc_source::", "ingest::")
-            .rename_type("ingest_model::gapc_part::", "ingest::")
-            .rename_type("ingest_model::gapc_part_type::", "ingest::")
-            .rename_type("ingest_model::store::", "ingest::")
-            .rename_type("ingest_model::gapc_part_attribute::", "ingest::")
-            .rename_type("ingest_model::gapc_part_fitment::", "ingest::")
-            .rename_type("ingest_model::uvdb_property::", "ingest::")
-            .rename_type("ingest_model::gapc_part_position::", "ingest::")
-            .rename_type("ingest_model::uvdb_vehicle_definition::", "ingest::")
-            .rename_type("ingest_model::gapc_part_inheritance::", "ingest::")
-            .rename_type("ingest_model::gapc_part_interchange::", "ingest::")
-            .rename_type("ingest_model::ingest_gapc_part::", "ingest::")
-            .rename_type("ingest_model::ingest_generic::", "ingest::")
-            .rename_type("ingest_model::upload::", "ingest::")
-            .rename_type("ingest_model::ingest_sellable::", "ingest::")
-            .rename_type("ingest_model::sellable_tag::", "ingest::")
-            .rename_type("ingest_model::sellable_integration::", "ingest::")
-            .rename_type("ingest_model::sellable_inventory::", "ingest::")
-            .rename_type("ingest_model::ingest_item_issue::", "ingest::")
-            .rename_type("ingest_model::json_types::", "ingest::")
-            .rename_type("ingest::model::ingest_result::", "ingest::")
-            .rename_type("ingest::model::ingest_item_issue::", "ingest::")
-            .rename_type("ingest::model::ingest_item_warning::", "ingest::")
-            .rename_type("ingest::model::ingest_error::", "ingest::")
-            .rename_type("ingest::model::", "ingest::")
-            .rename_type("reflectapi_ex::types_nomatches::", "nomatches::")
-            .rename_type("core_server_upload::upload_entity::", "upload::")
-            .rename_type("core_server_upload::upload_entity_issue::", "upload::")
-            .rename_type("core_server_upload::model::", "upload::")
-            .rename_type("core_server_upload::error::", "upload::")
-            .rename_type("core_server_upload::", "upload::")
+        .glob_rename_types("ingest_model::**", "ingest::")
+        .glob_rename_types("ingest::model::**", "ingest::")
+        .rename_type("reflectapi_ex::types_nomatches::", "nomatches::")
+        .rename_type("core_server_upload::upload_entity::", "upload::")
+        .rename_type("core_server_upload::upload_entity_issue::", "upload::")
+        .rename_type("core_server_upload::model::", "upload::")
+        .rename_type("core_server_upload::error::", "upload::")
+        .rename_type("core_server_upload::", "upload::")
 }
```