### PR TITLE
Option to hide routes from documentation

### DIFF
--- a/reflectapi-demo/openapi.json
+++ b/reflectapi-demo/openapi.json
@@ -6,27 +6,6 @@
     "version": "1.0.0"
   },
   "paths": {
-    "/health.check": {
-      "description": "Check the health of the service",
-      "post": {
-        "operationId": "health.check",
-        "description": "Check the health of the service",
-        "responses": {
-          "200": {
-            "description": "200 OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "empty object",
-                  "type": "object",
-                  "properties": {}
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/pets.create": {
       "description": "Create a new pet",
       "post": {

--- a/reflectapi-demo/reflectapi.json
+++ b/reflectapi-demo/reflectapi.json
@@ -9,7 +9,10 @@
       "serialization": [
         "json"
       ],
-      "readonly": true
+      "readonly": true,
+      "tags": [
+        "internal"
+      ]
     },
     {
       "name": "pets.list",

--- a/reflectapi-demo/src/lib.rs
+++ b/reflectapi-demo/src/lib.rs
@@ -12,6 +12,7 @@ pub fn builder() -> reflectapi::Builder<Arc<AppState>> {
         .route(health_check, |b| {
             b.name("health.check".into())
                 .readonly(true)
+                .tag("internal")
                 .description("Check the health of the service".into())
         })
         .route(pets_list, |b| {

--- a/reflectapi-demo/src/tests/assert.rs
+++ b/reflectapi-demo/src/tests/assert.rs
@@ -11,7 +11,7 @@ fn mk_config() -> reflectapi::codegen::Config {
         format: true,
         // Typechecking is too slow to run locally on every test
         typecheck: std::env::var("CI").is_ok(),
-        shared_modules: vec![],
+        ..Default::default()
     }
 }
 
@@ -162,7 +162,7 @@ macro_rules! assert_builder_snapshot {
         let config = reflectapi::codegen::Config {
             format: true,
             typecheck: true,
-            shared_modules: vec![],
+            ..Default::default()
         };
         let rust = reflectapi::codegen::rust::generate(schema.clone(), &config).unwrap();
         let typescript =

--- a/reflectapi-demo/src/tests/mod.rs
+++ b/reflectapi-demo/src/tests/mod.rs
@@ -25,8 +25,15 @@ fn write_schema() {
 fn write_openapi_spec() {
     let (schema, _) = crate::builder().build().unwrap();
 
-    let spec = reflectapi::codegen::openapi::Spec::from(&schema);
-    let s = serde_json::to_string_pretty(&spec).unwrap();
+    let s = reflectapi::codegen::openapi::generate(
+        schema,
+        &reflectapi::codegen::Config {
+            format: true,
+            exclude_tags: vec!["internal".to_string()],
+            ..Default::default()
+        },
+    )
+    .unwrap();
 
     std::fs::write(format!("{}/openapi.json", env!("CARGO_MANIFEST_DIR")), &s).unwrap();
     insta::assert_snapshot!(s);
@@ -40,7 +47,7 @@ fn write_rust_client() {
         &reflectapi::codegen::Config {
             format: true,
             typecheck: false,
-            shared_modules: vec![],
+            ..Default::default()
         },
     )
     .unwrap();
@@ -62,8 +69,8 @@ fn write_typescript_client() {
         schema,
         &reflectapi::codegen::Config {
             format: true,
-            typecheck: false,
-            shared_modules: vec![],
+            typecheck: true,
+            ..Default::default()
         },
     )
     .unwrap();

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__write_openapi_spec.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__write_openapi_spec.snap
@@ -10,27 +10,6 @@ expression: s
     "version": "1.0.0"
   },
   "paths": {
-    "/health.check": {
-      "description": "Check the health of the service",
-      "post": {
-        "operationId": "health.check",
-        "description": "Check the health of the service",
-        "responses": {
-          "200": {
-            "description": "200 OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "empty object",
-                  "type": "object",
-                  "properties": {}
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/pets.create": {
       "description": "Create a new pet",
       "post": {

--- a/reflectapi-schema/src/lib.rs
+++ b/reflectapi-schema/src/lib.rs
@@ -413,6 +413,10 @@ pub struct Function {
     /// If a function is readonly, it means it does not modify the state of an application
     #[serde(skip_serializing_if = "is_false", default)]
     pub readonly: bool,
+
+    /// If a function is hidden, it means it should not be displayed in the documentation
+    #[serde(skip_serializing_if = "is_false", default)]
+    pub hidden: bool,
 }
 
 impl Function {
@@ -427,6 +431,7 @@ impl Function {
             error_type: None,
             serialization: Vec::new(),
             readonly: false,
+            hidden: false,
         }
     }
 

--- a/reflectapi-schema/src/lib.rs
+++ b/reflectapi-schema/src/lib.rs
@@ -16,6 +16,7 @@ pub use glob::PatternError;
 
 pub use self::rename::*;
 use core::fmt;
+use std::collections::BTreeSet;
 use std::{
     collections::HashMap,
     ops::{ControlFlow, Index},
@@ -414,9 +415,8 @@ pub struct Function {
     #[serde(skip_serializing_if = "is_false", default)]
     pub readonly: bool,
 
-    /// If a function is hidden, it means it should not be displayed in the documentation
-    #[serde(skip_serializing_if = "is_false", default)]
-    pub hidden: bool,
+    #[serde(skip_serializing_if = "BTreeSet::is_empty", default)]
+    pub tags: BTreeSet<String>,
 }
 
 impl Function {
@@ -429,9 +429,9 @@ impl Function {
             input_headers: None,
             output_type: None,
             error_type: None,
-            serialization: Vec::new(),
+            serialization: Default::default(),
             readonly: false,
-            hidden: false,
+            tags: Default::default(),
         }
     }
 

--- a/reflectapi/src/axum.rs
+++ b/reflectapi/src/axum.rs
@@ -33,6 +33,7 @@ where
             readonly,
             input_headers,
             callback,
+            hidden: _,
         } = handler;
         let axum_handler = {
             let shared_state = app_state.clone();

--- a/reflectapi/src/axum.rs
+++ b/reflectapi/src/axum.rs
@@ -33,7 +33,6 @@ where
             readonly,
             input_headers,
             callback,
-            hidden: _,
         } = handler;
         let axum_handler = {
             let shared_state = app_state.clone();

--- a/reflectapi/src/builder/handler.rs
+++ b/reflectapi/src/builder/handler.rs
@@ -80,7 +80,6 @@ where
     pub name: String,
     pub path: String,
     pub readonly: bool,
-    pub hidden: bool,
     pub input_headers: Vec<String>,
     pub callback: Arc<HandlerCallback<S>>,
 }
@@ -94,7 +93,6 @@ where
             .field("name", &self.name)
             .field("path", &self.path)
             .field("readonly", &self.readonly)
-            .field("hidden", &self.hidden)
             .field("input_headers", &self.input_headers)
             .finish()
     }
@@ -161,7 +159,7 @@ where
             },
             serialization: vec![crate::SerializationMode::Json],
             readonly: rb.readonly,
-            hidden: rb.hidden,
+            tags: rb.tags,
         };
         schema.functions.push(function_def);
 
@@ -173,7 +171,6 @@ where
             name: rb.name,
             path: rb.path,
             readonly: rb.readonly,
-            hidden: rb.hidden,
             input_headers: input_headers_names.clone(),
             callback: Arc::new(move |state: S, input: HandlerInput| {
                 Box::pin(Self::handler_wrap(state, input, handler)) as _

--- a/reflectapi/src/builder/mod.rs
+++ b/reflectapi/src/builder/mod.rs
@@ -101,14 +101,7 @@ where
         E: crate::Output + serde::ser::Serialize + crate::StatusCode + Send + 'static,
     {
         let rb = builder(RouteBuilder::new().path(self.path.clone()));
-        let route = crate::Handler::new(
-            rb.name,
-            rb.path,
-            rb.description,
-            rb.readonly,
-            handler,
-            &mut self.schema,
-        );
+        let route = crate::Handler::new(rb, handler, &mut self.schema);
         self.handlers.push(route);
         self
     }
@@ -215,27 +208,18 @@ where
     pub handlers: Vec<crate::Handler<S>>,
 }
 
+#[derive(Default)]
 pub struct RouteBuilder {
     name: String,
     path: String,
     description: String,
     readonly: bool,
-}
-
-impl Default for RouteBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
+    hidden: bool,
 }
 
 impl RouteBuilder {
     pub fn new() -> Self {
-        Self {
-            name: String::new(),
-            path: String::from(""),
-            description: String::new(),
-            readonly: false,
-        }
+        Default::default()
     }
 
     pub fn name(mut self, name: String) -> Self {
@@ -261,6 +245,11 @@ impl RouteBuilder {
 
     pub fn readonly(mut self, readonly: bool) -> Self {
         self.readonly = readonly;
+        self
+    }
+
+    pub fn hidden(mut self, hidden: bool) -> Self {
+        self.hidden = hidden;
         self
     }
 }

--- a/reflectapi/src/builder/mod.rs
+++ b/reflectapi/src/builder/mod.rs
@@ -2,7 +2,7 @@ mod handler;
 mod result;
 
 use core::fmt;
-use std::error::Error;
+use std::{borrow::Borrow, collections::BTreeSet, error::Error};
 
 pub use handler::*;
 use reflectapi_schema::Pattern;
@@ -214,7 +214,7 @@ pub struct RouteBuilder {
     path: String,
     description: String,
     readonly: bool,
-    hidden: bool,
+    tags: BTreeSet<String>,
 }
 
 impl RouteBuilder {
@@ -248,8 +248,22 @@ impl RouteBuilder {
         self
     }
 
-    pub fn hidden(mut self, hidden: bool) -> Self {
-        self.hidden = hidden;
+    pub fn tag(mut self, tag: impl Into<String>) -> Self {
+        self.tags.insert(tag.into());
+        self
+    }
+
+    pub fn untag<Q>(mut self, tag: &Q) -> Self
+    where
+        String: Borrow<Q>,
+        Q: Ord + ?Sized,
+    {
+        self.tags.remove(tag);
+        self
+    }
+
+    pub fn tags(mut self, tags: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.tags.extend(tags.into_iter().map(Into::into));
         self
     }
 }

--- a/reflectapi/src/codegen/mod.rs
+++ b/reflectapi/src/codegen/mod.rs
@@ -17,6 +17,10 @@ pub struct Config {
     /// Typecheck the generated code. Will ignore if the typechecker is not available.
     pub typecheck: bool,
     pub shared_modules: Vec<String>,
+    /// Only include handlers with these tags (empty means include all).
+    pub include_tags: Vec<String>,
+    /// Exclude handlers with these tags (empty means exclude none).
+    pub exclude_tags: Vec<String>,
 }
 
 fn tmp_path(src: &str) -> PathBuf {


### PR DESCRIPTION
Note for future, include and exclude tags also makes sense for generated clients but not implemented here.