### PR TITLE
Parse content-type properly as mime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,6 +1467,7 @@ dependencies = [
  "chrono",
  "http 1.1.0",
  "indexmap",
+ "mime",
  "reflectapi-derive",
  "reflectapi-schema",
  "reqwest",

--- a/reflectapi-demo/requests/json.http
+++ b/reflectapi-demo/requests/json.http
@@ -1,5 +1,5 @@
 POST http://localhost:3000/pets.create
-Content-Type:  application/json
+Content-Type:  application/json; charset=utf-8
 Authorization: password
 traceparent:   blah
 name: 1

--- a/reflectapi/Cargo.toml
+++ b/reflectapi/Cargo.toml
@@ -30,6 +30,7 @@ serde = { version = "1.0.197", features = ["derive"] }
 serde_json = { version = "1.0.114", optional = true }
 bytes = { version = "1.5.0", optional = true }
 http = { version = "1.1.0", optional = true }
+mime = { version = "0.3.17", optional = true }
 
 # optional 3rd party dependencies for additional serialization formats
 rmp-serde = {version = "1.3.0", optional = true }
@@ -59,7 +60,7 @@ serde_json = { version = "1.0.114" }
 [features]
 default = ["glob"]
 # feature for implementing schema builder
-builder = ["dep:serde_json", "dep:bytes", "dep:http"]
+builder = ["dep:serde_json", "dep:bytes", "dep:http", "dep:mime"]
 msgpack = ["dep:rmp-serde", "builder"]
 # features for implementing reflect traits for foreigh types
 uuid = ["dep:uuid"]


### PR DESCRIPTION
This prevents content-type parameters such as charset from failing to parse.

Diff is pretty bad, full function is below.

```
impl TryFrom<&http::HeaderMap> for ContentType {
    type Error = anyhow::Error;

    fn try_from(value: &http::HeaderMap) -> Result<Self, Self::Error> {
        match value.get("content-type") {
            Some(v) => {
                let mime = v.to_str()?.parse::<mime::Mime>()?;
                if let Some(charset) = mime.get_param(mime::CHARSET) {
                    if charset != mime::UTF_8 {
                        return Err(anyhow::anyhow!("unsupported charset: {charset}"));
                    }
                }

                if mime.type_() != mime::APPLICATION {
                    return Err(anyhow::anyhow!("unsupported media type: {mime}"));
                }

                match mime.subtype() {
                    mime::JSON => Ok(ContentType::Json),
                    #[cfg(feature = "msgpack")]
                    mime::MSGPACK => Ok(ContentType::MessagePack),
                    _ => anyhow::bail!("unsupported content-type: {mime}"),
                }
            }
            None => Ok(ContentType::Json),
        }
    }
}
```