### PR TITLE
feat(openapi): document error types

### DIFF
--- a/reflectapi-demo/clients/rust/generated/src/generated.rs
+++ b/reflectapi-demo/clients/rust/generated/src/generated.rs
@@ -261,7 +261,7 @@ pub mod types {
 
             #[derive(Debug, serde::Deserialize)]
             pub enum PetsListError {
-                InvalidCustor,
+                InvalidCursor,
                 Unauthorized,
             }
 

--- a/reflectapi-demo/clients/typescript/generated.ts
+++ b/reflectapi-demo/clients/typescript/generated.ts
@@ -280,7 +280,7 @@ export namespace myapi {
 
     export type PetsCreateRequest = myapi.model.Pet;
 
-    export type PetsListError = "InvalidCustor" | "Unauthorized";
+    export type PetsListError = "InvalidCursor" | "Unauthorized";
 
     export interface PetsListRequest {
       limit?: number /* u8 */ | null;

--- a/reflectapi-demo/openapi.json
+++ b/reflectapi-demo/openapi.json
@@ -54,6 +54,16 @@
                 }
               }
             }
+          },
+          "default": {
+            "description": "Error cases",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/myapi.proto.PetsCreateError"
+                }
+              }
+            }
           }
         },
         "parameters": [
@@ -88,6 +98,16 @@
                       "$ref": "#/components/schemas/myapi.model.Pet"
                     }
                   ]
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error cases",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/myapi.proto.UnauthorizedError"
                 }
               }
             }
@@ -154,6 +174,16 @@
                 }
               }
             }
+          },
+          "default": {
+            "description": "Error cases",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/myapi.proto.PetsListError"
+                }
+              }
+            }
           }
         },
         "parameters": [
@@ -195,6 +225,16 @@
                 }
               }
             }
+          },
+          "default": {
+            "description": "Error cases",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/myapi.proto.PetsRemoveError"
+                }
+              }
+            }
           }
         },
         "parameters": [
@@ -233,6 +273,16 @@
                   "description": "empty object",
                   "type": "object",
                   "properties": {}
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error cases",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/myapi.proto.PetsUpdateError"
                 }
               }
             }
@@ -354,11 +404,52 @@
           }
         }
       },
+      "myapi.proto.PetsCreateError": {
+        "oneOf": [
+          {
+            "const": "Conflict"
+          },
+          {
+            "const": "NotAuthorized"
+          },
+          {
+            "type": "object",
+            "title": "InvalidIdentity",
+            "required": [
+              "InvalidIdentity"
+            ],
+            "properties": {
+              "InvalidIdentity": {
+                "type": "object",
+                "title": "InvalidIdentity",
+                "required": [
+                  "message"
+                ],
+                "properties": {
+                  "message": {
+                    "$ref": "#/components/schemas/std.string.String"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
       "myapi.proto.PetsCreateRequest": {
         "type": "array",
         "prefixItems": [
           {
             "$ref": "#/components/schemas/myapi.model.Pet"
+          }
+        ]
+      },
+      "myapi.proto.PetsListError": {
+        "oneOf": [
+          {
+            "const": "InvalidCursor"
+          },
+          {
+            "const": "Unauthorized"
           }
         ]
       },
@@ -390,6 +481,16 @@
           }
         }
       },
+      "myapi.proto.PetsRemoveError": {
+        "oneOf": [
+          {
+            "const": "NotFound"
+          },
+          {
+            "const": "NotAuthorized"
+          }
+        ]
+      },
       "myapi.proto.PetsRemoveRequest": {
         "type": "object",
         "title": "myapi.proto.PetsRemoveRequest",
@@ -401,6 +502,16 @@
             "$ref": "#/components/schemas/std.string.String"
           }
         }
+      },
+      "myapi.proto.PetsUpdateError": {
+        "oneOf": [
+          {
+            "const": "NotFound"
+          },
+          {
+            "const": "NotAuthorized"
+          }
+        ]
       },
       "myapi.proto.PetsUpdateRequest": {
         "type": "object",
@@ -451,9 +562,21 @@
           }
         }
       },
+      "myapi.proto.UnauthorizedError": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "$ref": "#/components/schemas/std.tuple.Tuple0"
+          }
+        ]
+      },
       "std.string.String": {
         "description": "UTF-8 encoded string",
         "type": "string"
+      },
+      "std.tuple.Tuple0": {
+        "description": "Unit type",
+        "type": "null"
       },
       "u8": {
         "description": "8-bit unsigned integer",

--- a/reflectapi-demo/reflectapi.json
+++ b/reflectapi-demo/reflectapi.json
@@ -664,7 +664,7 @@
         "name": "myapi::proto::PetsListError",
         "variants": [
           {
-            "name": "InvalidCustor",
+            "name": "InvalidCursor",
             "fields": "none"
           },
           {

--- a/reflectapi-demo/src/lib.rs
+++ b/reflectapi-demo/src/lib.rs
@@ -136,7 +136,7 @@ async fn pets_list(
         .cursor
         .unwrap_or("0".into())
         .parse()
-        .map_err(|_| proto::PetsListError::InvalidCustor)?;
+        .map_err(|_| proto::PetsListError::InvalidCursor)?;
     let limit = request.limit.unwrap_or(u8::MAX) as usize;
     let result_items = pets
         .iter()
@@ -273,14 +273,14 @@ mod proto {
 
     #[derive(serde::Serialize, reflectapi::Output)]
     pub enum PetsListError {
-        InvalidCustor,
+        InvalidCursor,
         Unauthorized,
     }
 
     impl reflectapi::StatusCode for PetsListError {
         fn status_code(&self) -> http::StatusCode {
             match self {
-                PetsListError::InvalidCustor => http::StatusCode::BAD_REQUEST,
+                PetsListError::InvalidCursor => http::StatusCode::BAD_REQUEST,
                 PetsListError::Unauthorized => http::StatusCode::UNAUTHORIZED,
             }
         }

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__write_openapi_spec.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__write_openapi_spec.snap
@@ -58,6 +58,16 @@ expression: s
                 }
               }
             }
+          },
+          "default": {
+            "description": "Error cases",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/myapi.proto.PetsCreateError"
+                }
+              }
+            }
           }
         },
         "parameters": [
@@ -92,6 +102,16 @@ expression: s
                       "$ref": "#/components/schemas/myapi.model.Pet"
                     }
                   ]
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error cases",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/myapi.proto.UnauthorizedError"
                 }
               }
             }
@@ -158,6 +178,16 @@ expression: s
                 }
               }
             }
+          },
+          "default": {
+            "description": "Error cases",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/myapi.proto.PetsListError"
+                }
+              }
+            }
           }
         },
         "parameters": [
@@ -199,6 +229,16 @@ expression: s
                 }
               }
             }
+          },
+          "default": {
+            "description": "Error cases",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/myapi.proto.PetsRemoveError"
+                }
+              }
+            }
           }
         },
         "parameters": [
@@ -237,6 +277,16 @@ expression: s
                   "description": "empty object",
                   "type": "object",
                   "properties": {}
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error cases",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/myapi.proto.PetsUpdateError"
                 }
               }
             }
@@ -358,11 +408,52 @@ expression: s
           }
         }
       },
+      "myapi.proto.PetsCreateError": {
+        "oneOf": [
+          {
+            "const": "Conflict"
+          },
+          {
+            "const": "NotAuthorized"
+          },
+          {
+            "type": "object",
+            "title": "InvalidIdentity",
+            "required": [
+              "InvalidIdentity"
+            ],
+            "properties": {
+              "InvalidIdentity": {
+                "type": "object",
+                "title": "InvalidIdentity",
+                "required": [
+                  "message"
+                ],
+                "properties": {
+                  "message": {
+                    "$ref": "#/components/schemas/std.string.String"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
       "myapi.proto.PetsCreateRequest": {
         "type": "array",
         "prefixItems": [
           {
             "$ref": "#/components/schemas/myapi.model.Pet"
+          }
+        ]
+      },
+      "myapi.proto.PetsListError": {
+        "oneOf": [
+          {
+            "const": "InvalidCursor"
+          },
+          {
+            "const": "Unauthorized"
           }
         ]
       },
@@ -394,6 +485,16 @@ expression: s
           }
         }
       },
+      "myapi.proto.PetsRemoveError": {
+        "oneOf": [
+          {
+            "const": "NotFound"
+          },
+          {
+            "const": "NotAuthorized"
+          }
+        ]
+      },
       "myapi.proto.PetsRemoveRequest": {
         "type": "object",
         "title": "myapi.proto.PetsRemoveRequest",
@@ -405,6 +506,16 @@ expression: s
             "$ref": "#/components/schemas/std.string.String"
           }
         }
+      },
+      "myapi.proto.PetsUpdateError": {
+        "oneOf": [
+          {
+            "const": "NotFound"
+          },
+          {
+            "const": "NotAuthorized"
+          }
+        ]
       },
       "myapi.proto.PetsUpdateRequest": {
         "type": "object",
@@ -455,9 +566,21 @@ expression: s
           }
         }
       },
+      "myapi.proto.UnauthorizedError": {
+        "type": "array",
+        "prefixItems": [
+          {
+            "$ref": "#/components/schemas/std.tuple.Tuple0"
+          }
+        ]
+      },
       "std.string.String": {
         "description": "UTF-8 encoded string",
         "type": "string"
+      },
+      "std.tuple.Tuple0": {
+        "description": "Unit type",
+        "type": "null"
       },
       "u8": {
         "description": "8-bit unsigned integer",


### PR DESCRIPTION
Taking easy approach for now and using `default` case. We could be smarter and document status code by status code but would require maintaining more information in `reflectapi.json` than we currently have.