### PR TITLE
Handle internal(5xx) errors as unstructured `other_err`

### DIFF
--- a/reflectapi/src/codegen/lib.ts
+++ b/reflectapi/src/codegen/lib.ts
@@ -176,33 +176,33 @@ export function __request<I, H, O, E>(
   return client
     .request(path, JSON.stringify(input), hdrs)
     .then(([status, response_body]) => {
-      if (status < 200 || status >= 300) {
-        let parsed_response_body;
+      if (status >= 200 && status < 300) {
         try {
-          parsed_response_body = JSON.parse(response_body);
+          return new Result<O, Err<E>>({ ok: JSON.parse(response_body) as O });
+        } catch (e) {
+          return new Result<O, Err<E>>({
+            err: new Err({
+              other_err:
+                "internal error: failure to parse response body as json on successful status code: " +
+                response_body,
+            }),
+          });
+        }
+      } else if (status >= 500) {
+        return new Result<O, Err<E>>({
+          err: new Err({ other_err: `[${status}] ${response_body}` }),
+        })
+      } else {
+        try {
+          return new Result<O, Err<E>>({
+            err: new Err({ application_err: JSON.parse(response_body) as E }),
+          });
         } catch (e) {
           return new Result<O, Err<E>>({
             err: new Err({ other_err: `[${status}] ${response_body}` }),
           });
         }
-        return new Result<O, Err<E>>({
-          err: new Err({ application_err: parsed_response_body as E }),
-        });
       }
-
-      let parsed_response_body;
-      try {
-        parsed_response_body = JSON.parse(response_body);
-      } catch (e) {
-        return new Result<O, Err<E>>({
-          err: new Err({
-            other_err:
-              "internal error: failure to parse response body as json on successful status code: " +
-              response_body,
-          }),
-        });
-      }
-      return new Result<O, Err<E>>({ ok: parsed_response_body as O });
     })
     .catch((e) => {
       return new Result<O, Err<E>>({ err: new Err({ other_err: e }) });

--- a/reflectapi/src/codegen/rust-dependency-stubs/http.rs
+++ b/reflectapi/src/codegen/rust-dependency-stubs/http.rs
@@ -14,6 +14,10 @@ impl StatusCode {
         unimplemented!()
     }
 
+    pub fn is_server_error(&self) -> bool {
+        unimplemented!()
+    }
+
     pub fn is_success(&self) -> bool {
         unimplemented!()
     }

--- a/reflectapi/src/rt.rs
+++ b/reflectapi/src/rt.rs
@@ -174,12 +174,12 @@ where
         return Ok(output);
     }
     match serde_json::from_slice::<E>(&body) {
-        Ok(error) => Err(Error::Application(error)),
+        Ok(error) if !status.is_server_error() => Err(Error::Application(error)),
         Err(e) if status.is_client_error() => Err(Error::Protocol {
             info: e.to_string(),
             stage: ProtocolErrorStage::DeserializeResponseError(status, body),
         }),
-        Err(_) => Err(Error::Server(status, body)),
+        _ => Err(Error::Server(status, body)),
     }
 }
 


### PR DESCRIPTION
Full logic might be clearer than the diff.

```rust
      if (status >= 200 && status < 300) {
        try {
          return new Result<O, Err<E>>({ ok: JSON.parse(response_body) as O });
        } catch (e) {
          return new Result<O, Err<E>>({
            err: new Err({
              other_err:
                "internal error: failure to parse response body as json on successful status code: " +
                response_body,
            }),
          });
        }
      } else if (status >= 500) {
        // The new condition
        return new Result<O, Err<E>>({
          err: new Err({ other_err: `[${status}] ${response_body}` }),
        })
      } else {
        try {
          return new Result<O, Err<E>>({
            err: new Err({ application_err: JSON.parse(response_body) as E }),
          });
        } catch (e) {
          return new Result<O, Err<E>>({
            err: new Err({ other_err: `[${status}] ${response_body}` }),
          });
        }
      }
```