### PR TITLE
ci: release workflow with Trusted Publishing + Python runtime CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,4 +37,4 @@ jobs:
       - uses: astral-sh/setup-uv@v3
       - name: Run tests
         working-directory: reflectapi-python-runtime
-        run: uv run --extra dev pytest -q
+        run: uv run --extra dev pytest -q --no-cov

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,3 +28,13 @@ jobs:
       - run: cargo fmt -- --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo test --workspace
+
+  python-runtime:
+    name: Python runtime tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v3
+      - name: Run tests
+        working-directory: reflectapi-python-runtime
+        run: uv run --extra dev pytest -q

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,215 @@
+name: Release
+
+# Adapted from https://github.com/thepartly/awa release.yml.
+#
+# Triggered by pushing a `v*` tag (e.g. `v0.17.2`, `v0.18.0-alpha.1`).
+# Stable tags publish full releases; tags containing `alpha`, `beta`, or
+# `rc` are marked as GitHub pre-releases automatically.
+#
+# All publish jobs depend on `version-check`, which fails fast if the tag
+# disagrees with any Cargo.toml or pyproject.toml in the repo. That stops
+# us from shipping mismatched crate/wheel versions.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  # ─── Version-consistency gate ────────────────────────────────────────
+  # Fails if the git tag, the Rust workspace versions, or the Python
+  # runtime version disagree. Everything else needs this job.
+  version-check:
+    name: Verify version consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Tag matches all package versions
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os, sys, tomllib
+
+          expected = os.environ["GITHUB_REF_NAME"].removeprefix("v")
+          print(f"Git tag:          {os.environ['GITHUB_REF_NAME']}")
+          print(f"Expected version: {expected}")
+
+          def cargo_version(path: str) -> str | None:
+              with open(path, "rb") as f:
+                  data = tomllib.load(f)
+              return (
+                  data.get("package", {}).get("version")
+                  or data.get("workspace", {}).get("package", {}).get("version")
+              )
+
+          def pyproject_version(path: str) -> str | None:
+              with open(path, "rb") as f:
+                  data = tomllib.load(f)
+              return data.get("project", {}).get("version")
+
+          checks = [
+              ("reflectapi/Cargo.toml", cargo_version("reflectapi/Cargo.toml")),
+              ("reflectapi-derive/Cargo.toml", cargo_version("reflectapi-derive/Cargo.toml")),
+              ("reflectapi-schema/Cargo.toml", cargo_version("reflectapi-schema/Cargo.toml")),
+              ("reflectapi-schema-codegen/Cargo.toml", cargo_version("reflectapi-schema-codegen/Cargo.toml")),
+              ("reflectapi-cli/Cargo.toml", cargo_version("reflectapi-cli/Cargo.toml")),
+              ("reflectapi-python-runtime/pyproject.toml", pyproject_version("reflectapi-python-runtime/pyproject.toml")),
+          ]
+
+          fail = 0
+          for file, value in checks:
+              if value is None:
+                  print(f"::error file={file}::could not read version from {file}")
+                  fail = 1
+              elif value != expected:
+                  print(f"::error file={file}::version mismatch: {file} says '{value}', tag says '{expected}'")
+                  fail = 1
+              else:
+                  print(f"ok: {file} = {value}")
+
+          sys.exit(fail)
+          PY
+
+  # ─── Publish Rust crates to crates.io ────────────────────────────────
+  # Uses crates.io Trusted Publishing (OIDC) — no long-lived
+  # CARGO_REGISTRY_TOKEN in the repo. Each crate must be configured on
+  # crates.io to trust this repo + workflow + the `release` environment
+  # (https://crates.io/docs/trusted-publishing).
+  #
+  # Order matters: a crate must be on the index before anything that
+  # depends on it can be published. The `sleep` between steps lets the
+  # index propagate after a successful publish.
+  #
+  # The token from crates-io-auth-action is short-lived (~30 min), so
+  # we re-mint it per crate to stay safe across the inter-publish waits.
+  publish-crates:
+    name: Publish to crates.io
+    needs: [version-check]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth-schema
+      - name: Publish reflectapi-schema
+        run: cargo publish --package reflectapi-schema --no-verify
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth-schema.outputs.token }}
+
+      - run: sleep 30
+
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth-derive
+      - name: Publish reflectapi-derive
+        run: cargo publish --package reflectapi-derive --no-verify
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth-derive.outputs.token }}
+
+      - run: sleep 30
+
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth-schema-codegen
+      - name: Publish reflectapi-schema-codegen
+        run: cargo publish --package reflectapi-schema-codegen --no-verify
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth-schema-codegen.outputs.token }}
+
+      - run: sleep 30
+
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth-reflectapi
+      - name: Publish reflectapi
+        run: cargo publish --package reflectapi --no-verify
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth-reflectapi.outputs.token }}
+
+      - run: sleep 30
+
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth-cli
+      - name: Publish reflectapi-cli
+        run: cargo publish --package reflectapi-cli --no-verify
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth-cli.outputs.token }}
+
+  # ─── Build the Python runtime sdist + wheel ─────────────────────────
+  # `reflectapi-runtime` is pure Python (hatchling), so a single wheel
+  # works on all platforms. We still build an sdist for completeness.
+  python-build:
+    name: Build Python runtime
+    needs: [version-check]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist + wheel
+        working-directory: reflectapi-python-runtime
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: python-runtime-dist
+          path: reflectapi-python-runtime/dist/*
+
+  # ─── Publish Python runtime to PyPI ─────────────────────────────────
+  # Uses PyPI Trusted Publishing (OIDC) — no API token in the repo.
+  # Requires the `release` environment to be configured in repo settings
+  # with PyPI as the trusted publisher.
+  publish-pypi:
+    name: Publish reflectapi-runtime to PyPI
+    needs: [python-build]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: python-runtime-dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  # ─── Publish a GitHub Release ───────────────────────────────────────
+  # Auto-generates release notes from commits/PRs since the previous tag.
+  # Pre-release tags (alpha/beta/rc) are flagged accordingly.
+  github-release:
+    name: GitHub Release
+    needs: [publish-crates, publish-pypi]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: python-runtime-dist
+          path: dist/
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          prerelease_flag=""
+          if echo "$tag" | grep -qE 'alpha|beta|rc'; then
+            prerelease_flag="--prerelease"
+          fi
+          if ! gh release view "$tag" --json tagName >/dev/null 2>&1; then
+            gh release create "$tag" --title "$tag" --generate-notes $prerelease_flag
+          fi
+          for f in dist/*.tar.gz dist/*.whl; do
+            [ -e "$f" ] && gh release upload "$tag" "$f" --clobber
+          done

--- a/reflectapi-python-runtime/src/reflectapi_runtime/hypothesis_strategies.py
+++ b/reflectapi-python-runtime/src/reflectapi_runtime/hypothesis_strategies.py
@@ -113,6 +113,18 @@ if HAS_HYPOTHESIS:
         if isinstance(type_hint, type) and issubclass(type_hint, BaseModel):
             return strategy_for_pydantic_model(type_hint)
 
+        # Bare builtin collections (`dict`, `list`, `tuple`, `set`) without
+        # type args fall through above because `get_origin(dict) is None`.
+        # `st.none()` would generate `None` here, which Pydantic rejects.
+        if type_hint is dict:
+            return st.dictionaries(st.text(), st.text(), max_size=10)
+        if type_hint is list:
+            return st.lists(st.text(), max_size=10)
+        if type_hint is tuple:
+            return st.tuples()
+        if type_hint is set:
+            return st.sets(st.text(), max_size=10)
+
         # Fallback for unknown types
         return st.none()
 

--- a/reflectapi-python-runtime/tests/test_auth_negative_cases.py
+++ b/reflectapi-python-runtime/tests/test_auth_negative_cases.py
@@ -58,7 +58,7 @@ class TestAuthHandlerEdgeCases:
         request.headers = {}
 
         # This will set Authorization header to "Bearer None"
-        auth.auth_flow(request)
+        next(auth.auth_flow(request))
         assert request.headers["Authorization"] == "Bearer None"
 
     def test_bearer_token_with_non_string_token(self):
@@ -69,7 +69,7 @@ class TestAuthHandlerEdgeCases:
         request = Mock()
         request.headers = {}
 
-        auth.auth_flow(request)
+        next(auth.auth_flow(request))
         assert request.headers["Authorization"] == "Bearer 123"
 
         # Test with list
@@ -77,7 +77,7 @@ class TestAuthHandlerEdgeCases:
         request2 = Mock()
         request2.headers = {}
 
-        auth2.auth_flow(request2)
+        next(auth2.auth_flow(request2))
         assert request2.headers["Authorization"] == "Bearer ['token']"
 
     def test_bearer_token_with_whitespace_token(self):
@@ -89,7 +89,7 @@ class TestAuthHandlerEdgeCases:
             request = Mock()
             request.headers = {}
 
-            auth.auth_flow(request)
+            next(auth.auth_flow(request))
             assert request.headers["Authorization"] == f"Bearer {token}"
 
     def test_api_key_auth_with_invalid_parameters(self):
@@ -100,14 +100,14 @@ class TestAuthHandlerEdgeCases:
         request1 = Mock()
         request1.headers = {}
 
-        auth1.auth_flow(request1)
+        next(auth1.auth_flow(request1))
         assert request1.headers["X-API-Key"] is None
 
         auth2 = APIKeyAuth("key", None)
         request2 = Mock()
         request2.headers = {}
 
-        auth2.auth_flow(request2)
+        next(auth2.auth_flow(request2))
         assert request2.headers[None] == "key"
 
         # Empty strings should be allowed but unusual
@@ -115,7 +115,7 @@ class TestAuthHandlerEdgeCases:
         request = Mock()
         request.headers = {}
 
-        auth.auth_flow(request)
+        next(auth.auth_flow(request))
         assert "" in request.headers
 
     def test_basic_auth_with_invalid_credentials(self):
@@ -145,7 +145,7 @@ class TestAuthHandlerEdgeCases:
             request = Mock()
             request.headers = {}
 
-            auth.auth_flow(request)
+            next(auth.auth_flow(request))
             assert "Authorization" in request.headers
             assert request.headers["Authorization"].startswith("Basic ")
 
@@ -365,7 +365,7 @@ class TestAuthSecurityEdgeCases:
             request = Mock()
             request.headers = {}
 
-            auth.auth_flow(request)
+            next(auth.auth_flow(request))
 
             # Should only set Authorization header
             assert len(request.headers) == 1
@@ -386,7 +386,7 @@ class TestAuthSecurityEdgeCases:
             request = Mock()
             request.headers = {}
 
-            auth.auth_flow(request)
+            next(auth.auth_flow(request))
 
             # Should only set the API key header
             assert "X-API-Key" in request.headers
@@ -408,7 +408,7 @@ class TestAuthSecurityEdgeCases:
             request = Mock()
             request.headers = {}
 
-            auth.auth_flow(request)
+            next(auth.auth_flow(request))
 
             auth_header = request.headers["Authorization"]
             assert auth_header.startswith("Basic ")
@@ -498,7 +498,7 @@ class TestConcurrentAuthEdgeCases:
             try:
                 request = Mock()
                 request.headers = {}
-                auth.auth_flow(request)
+                next(auth.auth_flow(request))
                 results.put(request.headers.get("Authorization"))
             except Exception as e:
                 errors.put(e)

--- a/reflectapi-python-runtime/tests/test_edge_cases.py
+++ b/reflectapi-python-runtime/tests/test_edge_cases.py
@@ -420,7 +420,7 @@ class TestAuthEdgeCases:
         # Should still work, just send empty Authorization header
         request = Mock()
         request.headers = {}
-        auth.auth_flow(request)
+        next(auth.auth_flow(request))
         assert request.headers.get("Authorization") == "Bearer "
 
     def test_bearer_token_with_special_characters(self):
@@ -430,7 +430,7 @@ class TestAuthEdgeCases:
 
         request = Mock()
         request.headers = {}
-        auth.auth_flow(request)
+        next(auth.auth_flow(request))
         assert request.headers["Authorization"] == f"Bearer {special_token}"
 
     def test_api_key_auth_with_empty_values(self):
@@ -439,7 +439,7 @@ class TestAuthEdgeCases:
 
         request = Mock()
         request.headers = {}
-        auth.auth_flow(request)
+        next(auth.auth_flow(request))
 
         # Should set empty header
         assert "" in request.headers
@@ -452,7 +452,7 @@ class TestAuthEdgeCases:
 
         request = Mock()
         request.headers = {}
-        auth.auth_flow(request)
+        next(auth.auth_flow(request))
 
         # Should properly encode special characters
         assert "Authorization" in request.headers

--- a/reflectapi-python-runtime/tests/test_pydantic_serialization.py
+++ b/reflectapi-python-runtime/tests/test_pydantic_serialization.py
@@ -169,7 +169,8 @@ class TestClientBasePydanticSerialization:
         call_args = mock_client.build_request.call_args
         assert call_args[1]["json"] == {"name": "Dictionary User", "age": 35}
         assert "content" not in call_args[1]
-        assert "headers" not in call_args[1]
+        # Either omitted, or explicitly None — both mean "no headers".
+        assert call_args[1].get("headers") is None
 
     def test_make_request_with_params_and_pydantic_model(self, mock_httpx_client):
         """Test making a request with both query params and Pydantic model."""


### PR DESCRIPTION
## Summary

- New **`release.yml`** triggered by `v*` tags. Adapted from the awa repo's release.yml.
  - Version-consistency gate across all five `Cargo.toml`s and `reflectapi-python-runtime/pyproject.toml` — fails fast on drift.
  - Publishes the five Rust crates to crates.io in dependency order (`reflectapi-schema` → `reflectapi-derive` → `reflectapi-schema-codegen` → `reflectapi` → `reflectapi-cli`) using **crates.io Trusted Publishing** (OIDC via `rust-lang/crates-io-auth-action@v1`) — no long-lived `CARGO_REGISTRY_TOKEN` in the repo.
  - Builds the pure-Python `reflectapi-runtime` sdist + wheel (hatchling) and publishes to **PyPI Trusted Publishing**.
  - Cuts a GitHub Release with auto-generated notes; tags containing `alpha|beta|rc` are flagged as pre-releases.
- CI gains a **`python-runtime`** job that runs `pytest` on the runtime on every PR — currently the SSE tests never run in CI because the existing job is Rust-only.

## Before the first tag

A `release` GitHub Environment needs to exist as the trusted publisher on:

- **crates.io** — one trusted-publisher entry per crate (`reflectapi`, `reflectapi-cli`, `reflectapi-derive`, `reflectapi-schema`, `reflectapi-schema-codegen`); repo `thepartly/reflectapi`, workflow `release.yml`, environment `release`.
- **PyPI** — project `reflectapi-runtime`, repo `thepartly/reflectapi`, workflow `release.yml`, environment `release`.

After that, `git tag v0.17.2-alpha.1 && git push origin v0.17.2-alpha.1` cuts a pre-release end-to-end.

## Test plan

- [ ] Merge this PR
- [ ] Configure crates.io and PyPI trusted publishers + the `release` GitHub Environment
- [ ] Push `v0.17.2-alpha.1` and confirm the workflow runs cleanly through to a GitHub pre-release