### PR TITLE
chore: 0.17.2-alpha.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,15 +31,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
       - name: Tag matches all package versions
         shell: bash
+        # SemVer (Cargo) and PEP 440 (Python) spell pre-releases
+        # differently — `0.17.2-alpha.1` vs `0.17.2a1`. We compare both
+        # against the tag using `packaging.version.Version`, which
+        # accepts both forms and normalises before equality.
         run: |
           set -euo pipefail
+          python3 -m pip install --quiet packaging
           python3 - <<'PY'
           import os, sys, tomllib
+          from packaging.version import InvalidVersion, Version
 
-          expected = os.environ["GITHUB_REF_NAME"].removeprefix("v")
-          print(f"Git tag:          {os.environ['GITHUB_REF_NAME']}")
+          tag = os.environ["GITHUB_REF_NAME"]
+          expected_str = tag.removeprefix("v")
+          try:
+              expected = Version(expected_str)
+          except InvalidVersion as e:
+              print(f"::error::tag '{tag}' is not a valid version: {e}")
+              sys.exit(1)
+          print(f"Git tag:          {tag}")
           print(f"Expected version: {expected}")
 
           def cargo_version(path: str) -> str | None:
@@ -65,15 +80,22 @@ jobs:
           ]
 
           fail = 0
-          for file, value in checks:
-              if value is None:
+          for file, raw in checks:
+              if raw is None:
                   print(f"::error file={file}::could not read version from {file}")
                   fail = 1
-              elif value != expected:
-                  print(f"::error file={file}::version mismatch: {file} says '{value}', tag says '{expected}'")
+                  continue
+              try:
+                  parsed = Version(raw)
+              except InvalidVersion as e:
+                  print(f"::error file={file}::'{raw}' is not a valid version: {e}")
+                  fail = 1
+                  continue
+              if parsed != expected:
+                  print(f"::error file={file}::version mismatch: {file} says '{raw}' ({parsed}), tag says '{expected_str}' ({expected})")
                   fail = 1
               else:
-                  print(f"ok: {file} = {value}")
+                  print(f"ok: {file} = {raw}")
 
           sys.exit(fail)
           PY

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1664,7 +1664,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi"
-version = "0.17.1"
+version = "0.17.2-alpha.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi-cli"
-version = "0.17.1"
+version = "0.17.2-alpha.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1754,7 +1754,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi-derive"
-version = "0.17.1"
+version = "0.17.2-alpha.1"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi-schema"
-version = "0.17.1"
+version = "0.17.2-alpha.1"
 dependencies = [
  "glob",
  "serde",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi-schema-codegen"
-version = "0.17.1"
+version = "0.17.2-alpha.1"
 dependencies = [
  "reflectapi-schema",
  "serde",

--- a/reflectapi-cli/Cargo.toml
+++ b/reflectapi-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi-cli"
-version = "0.17.1"
+version = "0.17.2-alpha.1"
 edition = "2021"
 default-run = "reflectapi"
 
@@ -23,7 +23,7 @@ doc = false
 workspace = true
 
 [dependencies]
-reflectapi = { path = "../reflectapi", version = "0.17.1", features = ["codegen"] }
+reflectapi = { path = "../reflectapi", version = "0.17.2-alpha.1", features = ["codegen"] }
 rouille = "3"
 
 clap = { version = "4.5.3", features = ["derive"] }

--- a/reflectapi-derive/Cargo.toml
+++ b/reflectapi-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi-derive"
-version = "0.17.1"
+version = "0.17.2-alpha.1"
 edition = "2021"
 
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ workspace = true
 proc-macro = true
 
 [dependencies]
-reflectapi-schema = { path = '../reflectapi-schema', version = "0.17.1" }
+reflectapi-schema = { path = '../reflectapi-schema', version = "0.17.2-alpha.1" }
 
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/reflectapi-python-runtime/pyproject.toml
+++ b/reflectapi-python-runtime/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "reflectapi-runtime"
-version = "0.17.1"
+version = "0.17.2a1"
 description = "Runtime library for ReflectAPI Python clients"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/reflectapi-python-runtime/src/reflectapi_runtime/__init__.py
+++ b/reflectapi-python-runtime/src/reflectapi_runtime/__init__.py
@@ -55,7 +55,7 @@ from .testing import (
 )
 from .types import BatchResult, ReflectapiEmpty, ReflectapiInfallible
 
-__version__ = "0.17.1"
+__version__ = "0.17.2a1"
 
 __all__ = [
     # Authentication

--- a/reflectapi-schema-codegen/Cargo.toml
+++ b/reflectapi-schema-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi-schema-codegen"
-version = "0.17.1"
+version = "0.17.2-alpha.1"
 edition = "2021"
 
 license = "Apache-2.0"
@@ -17,5 +17,5 @@ categories = ["web-programming", "development-tools", "api-bindings"]
 workspace = true
 
 [dependencies]
-reflectapi-schema = { path = "../reflectapi-schema", version = "0.17.1" }
+reflectapi-schema = { path = "../reflectapi-schema", version = "0.17.2-alpha.1" }
 serde = { version = "1.0.197", features = ["derive"] }

--- a/reflectapi-schema/Cargo.toml
+++ b/reflectapi-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi-schema"
-version = "0.17.1"
+version = "0.17.2-alpha.1"
 edition = "2021"
 
 license = "Apache-2.0"

--- a/reflectapi/Cargo.toml
+++ b/reflectapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi"
-version = "0.17.1"
+version = "0.17.2-alpha.1"
 edition = "2021"
 
 license = "Apache-2.0"
@@ -20,9 +20,9 @@ workspace = true
 
 [dependencies]
 # workspace dependencies
-reflectapi-derive = { path = "../reflectapi-derive", version = "0.17.1" }
-reflectapi-schema = { path = "../reflectapi-schema", version = "0.17.1" }
-reflectapi-schema-codegen = { path = "../reflectapi-schema-codegen", version = "0.17.1", optional = true }
+reflectapi-derive = { path = "../reflectapi-derive", version = "0.17.2-alpha.1" }
+reflectapi-schema = { path = "../reflectapi-schema", version = "0.17.2-alpha.1" }
+reflectapi-schema-codegen = { path = "../reflectapi-schema-codegen", version = "0.17.2-alpha.1", optional = true }
 
 # mandatory 3rd party dependencies
 serde = { version = "1.0.197", features = ["derive"] }


### PR DESCRIPTION
First alpha — purpose is to validate the release pipeline end-to-end against the just-set-up crates.io and PyPI Trusted Publishing.

## Versioning

- Cargo (SemVer pre-release): \`0.17.2-alpha.1\`
- Python (PEP 440 pre-release): \`0.17.2a1\`

These are the canonical forms for each ecosystem; Cargo rejects \`0.17.2a1\` and PEP 440 wants \`0.17.2a1\` (hatchling normalises any other spelling on build).

The release workflow's \`version-check\` now parses both via \`packaging.version.Version\` and compares normalised forms, so the single tag \`v0.17.2-alpha.1\` matches both kinds of source string.

## After merge

\`\`\`fish
git tag v0.17.2-alpha.1
git push origin v0.17.2-alpha.1
\`\`\`

That triggers \`release.yml\` which:

1. \`version-check\` against all six version sources
2. \`publish-crates\` — 5 crates to crates.io via OIDC (Trusted Publishing)
3. \`python-build\` + \`publish-pypi\` — \`reflectapi-runtime\` wheel/sdist via OIDC
4. \`github-release\` — auto-generated notes, alpha tag → marked pre-release

## Test plan

- [ ] Merge
- [ ] Push the tag and watch Actions
- [ ] Verify \`reflectapi*\` and \`reflectapi-runtime\` appear on crates.io / PyPI
- [ ] Verify the GitHub pre-release exists with wheel + sdist attached