### PR TITLE
fix(runtime): finish the transport-shape refactor

### DIFF
--- a/reflectapi-python-runtime/src/reflectapi_runtime/__init__.py
+++ b/reflectapi-python-runtime/src/reflectapi_runtime/__init__.py
@@ -19,14 +19,8 @@ from .auth import (
     oauth2_client_credentials,
 )
 from .batch import BatchClient
-from .client import (
-    AsyncClient,
-    AsyncClientBase,
-    Client,
-    ClientBase,
-    Request,
-    Response,
-)
+from .client import AsyncClientBase, ClientBase
+from .transport import AsyncClient, Client, Request, Response
 from .exceptions import (
     ApiError,
     ApplicationError,

--- a/reflectapi-python-runtime/src/reflectapi_runtime/client.py
+++ b/reflectapi-python-runtime/src/reflectapi_runtime/client.py
@@ -6,9 +6,8 @@ import datetime
 import json
 import time
 from abc import ABC
-from collections.abc import AsyncIterator, Iterator
-from dataclasses import dataclass
-from typing import Any, Protocol, TypeVar, overload, runtime_checkable
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+from typing import Any, TypeVar, overload
 
 import httpx
 from pydantic import BaseModel, TypeAdapter
@@ -25,6 +24,7 @@ from .middleware import (
 from .option import serialize_option_dict
 from .response import ApiResponse, TransportMetadata
 from .sse import aparse_sse, parse_sse
+from .transport import AsyncClient, Client, Request, Response
 
 
 # Sentinel object to represent "no validation needed"
@@ -35,43 +35,6 @@ class _NoValidation:
 NO_VALIDATION = _NoValidation()
 
 T = TypeVar("T", bound=BaseModel)
-
-
-@dataclass(frozen=True)
-class Request:
-    """Transport request passed to custom ReflectAPI Python clients.
-
-    ``method`` is intentionally absent: every reflectapi endpoint is POST
-    by design, so transports hardcode it. If that ever changes it's a
-    wire-protocol break and clients regenerate.
-    """
-
-    path: str
-    headers: dict[str, str]
-    body: bytes
-
-
-@dataclass(frozen=True)
-class Response:
-    """Transport response returned by custom ReflectAPI Python clients."""
-
-    status: int
-    headers: httpx.Headers
-    body: bytes
-
-
-@runtime_checkable
-class Client(Protocol):
-    """Synchronous transport protocol for generated clients."""
-
-    def request(self, request: Request) -> Response: ...
-
-
-@runtime_checkable
-class AsyncClient(Protocol):
-    """Asynchronous transport protocol for generated clients."""
-
-    async def request(self, request: Request) -> Response: ...
 
 
 def _json_serializer(obj: Any) -> Any:
@@ -361,6 +324,7 @@ class ClientBase(ABC):
 
     def _build_client_request(
         self,
+        path: str,
         json_data: Any | None,
         json_model: BaseModel | None,
         headers_model: BaseModel | None,
@@ -369,69 +333,77 @@ class ClientBase(ABC):
         if json_model is not None:
             content, base_headers = self._serialize_request_body(json_model)
             headers = self._build_headers(base_headers, headers_model)
-        else:
-            if json_data is not None:
-                if isinstance(json_data, dict):
-                    processed_json_data = serialize_option_dict(json_data)
-                else:
-                    processed_json_data = json_data
-                content = json.dumps(
-                    processed_json_data,
-                    default=_json_serializer,
-                    separators=(",", ":"),
-                ).encode("utf-8")
-                headers = self._build_headers(
-                    {"Content-Type": "application/json"}, headers_model
-                )
+        elif json_data is not None:
+            if isinstance(json_data, dict):
+                processed_json_data = serialize_option_dict(json_data)
             else:
-                content = b""
-                headers = self._build_headers({}, headers_model)
+                processed_json_data = json_data
+            content = json.dumps(
+                processed_json_data,
+                default=_json_serializer,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            headers = self._build_headers(
+                {"Content-Type": "application/json"}, headers_model
+            )
+        else:
+            content = b""
+            headers = self._build_headers({}, headers_model)
 
-        return Request(
-            path="",
-            headers=headers,
-            body=content,
-        )
+        return Request(path=path, headers=headers, body=content)
 
-    def _build_request(
+    def _build_httpx_request(
         self,
+        request: Request,
         url: str,
         params: dict[str, Any] | None,
-        json_data: Any | None,
-        json_model: BaseModel | None,
-        headers_model: BaseModel | None,
     ) -> httpx.Request:
-        """Build HTTP request object. Method is always POST by design."""
-        client_request = self._build_client_request(
-            json_data, json_model, headers_model
-        )
+        """Materialise an httpx.Request from a transport Request.
+
+        Method is always POST by design.
+        """
         request_kwargs: dict[str, Any] = {
             "method": "POST",
             "url": url,
             "params": params,
-            "headers": client_request.headers if client_request.headers else None,
+            "headers": request.headers if request.headers else None,
         }
-        if client_request.body:
-            request_kwargs["content"] = client_request.body
+        if request.body:
+            request_kwargs["content"] = request.body
         return self._client.build_request(**request_kwargs)
 
-    def _execute_client_request(self, request: Request) -> Response:
-        """Execute a request through the injected ReflectAPI transport."""
-        response = self._client.request(request)
-        if isinstance(response, httpx.Response):
-            return Response(
-                status=response.status_code,
-                headers=response.headers,
-                body=response.content,
-            )
-        return response
+    def _make_terminal(
+        self,
+        params: dict[str, Any] | None,
+    ) -> Callable[[Request], Response]:
+        """Return the chain-terminal handler for the active transport.
 
-    def _execute_request(self, request: httpx.Request) -> httpx.Response:
-        """Execute HTTP request through middleware chain."""
-        if self.middleware_chain.middleware:
-            return self.middleware_chain.execute(request, self._client)
-        else:
-            return self._client.send(request)
+        For an ``httpx.Client``, the terminal lifts the Request into an
+        ``httpx.Request``, sends it, and converts back. For a custom
+        :class:`Client`, the terminal calls ``client.request`` directly
+        and trusts the structural shape of the returned response.
+        """
+        if isinstance(self._client, httpx.Client):
+            base_url = self.base_url
+
+            def terminal(req: Request) -> Response:
+                url = f"{base_url}/{req.path.lstrip('/')}"
+                httpx_req = self._build_httpx_request(req, url, params)
+                httpx_resp = self._client.send(httpx_req)
+                return Response(
+                    status=httpx_resp.status_code,
+                    headers=httpx_resp.headers,
+                    body=httpx_resp.content,
+                )
+
+            return terminal
+
+        def terminal(req: Request) -> Response:
+            # Trust the structural shape: anything with .status / .headers
+            # / .body satisfies the Protocol.
+            return self._client.request(req)
+
+        return terminal
 
     def _handle_error_response(
         self,
@@ -528,33 +500,24 @@ class ClientBase(ABC):
         # Validate request parameters
         self._validate_request_params(json_data, json_model)
 
-        # Build URL and request
+        # Build the transport request once and drive it through the
+        # middleware chain. The chain's terminal handler is transport-
+        # specific; middleware itself is transport-agnostic.
         request = self._build_client_request(
-            json_data, json_model, headers_model
+            path, json_data, json_model, headers_model
         )
-        request = Request(
-            path=path,
-            headers=request.headers,
-            body=request.body,
-        )
+        terminal = self._make_terminal(params)
 
         # Execute request with timing
         start_time = time.time()
 
         try:
-            if hasattr(self._client, "build_request") and hasattr(self._client, "send"):
-                url = f"{self.base_url}/{path.lstrip('/')}"
-                httpx_request = self._build_request(
-                    url, params, json_data, json_model, headers_model
-                )
-                response = self._execute_request(httpx_request)
-            else:
-                client_response = self._execute_client_request(request)
-                response = httpx.Response(
-                    status_code=client_response.status,
-                    headers=client_response.headers,
-                    content=client_response.body,
-                )
+            client_response = self.middleware_chain.execute(request, terminal)
+            response = httpx.Response(
+                status_code=client_response.status,
+                headers=client_response.headers,
+                content=client_response.body,
+            )
             metadata = TransportMetadata.from_response(response, start_time)
 
             # Handle error responses
@@ -601,9 +564,10 @@ class ClientBase(ABC):
         self._validate_request_params(json_data, json_model)
 
         url = f"{self.base_url}/{path.lstrip('/')}"
-        request = self._build_request(
-            url, params, json_data, json_model, headers_model
+        client_request = self._build_client_request(
+            path, json_data, json_model, headers_model
         )
+        request = self._build_httpx_request(client_request, url, params)
         request.headers["accept"] = "text/event-stream"
 
         start_time = time.time()
@@ -924,6 +888,7 @@ class AsyncClientBase(ABC):
 
     def _build_client_request(
         self,
+        path: str,
         json_data: Any | None,
         json_model: BaseModel | None,
         headers_model: BaseModel | None,
@@ -932,69 +897,75 @@ class AsyncClientBase(ABC):
         if json_model is not None:
             content, base_headers = self._serialize_request_body(json_model)
             headers = self._build_headers(base_headers, headers_model)
-        else:
-            if json_data is not None:
-                if isinstance(json_data, dict):
-                    processed_json_data = serialize_option_dict(json_data)
-                else:
-                    processed_json_data = json_data
-                content = json.dumps(
-                    processed_json_data,
-                    default=_json_serializer,
-                    separators=(",", ":"),
-                ).encode("utf-8")
-                headers = self._build_headers(
-                    {"Content-Type": "application/json"}, headers_model
-                )
+        elif json_data is not None:
+            if isinstance(json_data, dict):
+                processed_json_data = serialize_option_dict(json_data)
             else:
-                content = b""
-                headers = self._build_headers({}, headers_model)
+                processed_json_data = json_data
+            content = json.dumps(
+                processed_json_data,
+                default=_json_serializer,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            headers = self._build_headers(
+                {"Content-Type": "application/json"}, headers_model
+            )
+        else:
+            content = b""
+            headers = self._build_headers({}, headers_model)
 
-        return Request(
-            path="",
-            headers=headers,
-            body=content,
-        )
+        return Request(path=path, headers=headers, body=content)
 
-    def _build_request(
+    def _build_httpx_request(
         self,
+        request: Request,
         url: str,
         params: dict[str, Any] | None,
-        json_data: Any | None,
-        json_model: BaseModel | None,
-        headers_model: BaseModel | None,
     ) -> httpx.Request:
-        """Build HTTP request object. Method is always POST by design."""
-        client_request = self._build_client_request(
-            json_data, json_model, headers_model
-        )
+        """Materialise an httpx.Request from a transport Request.
+
+        Method is always POST by design.
+        """
         request_kwargs: dict[str, Any] = {
             "method": "POST",
             "url": url,
             "params": params,
-            "headers": client_request.headers if client_request.headers else None,
+            "headers": request.headers if request.headers else None,
         }
-        if client_request.body:
-            request_kwargs["content"] = client_request.body
+        if request.body:
+            request_kwargs["content"] = request.body
         return self._client.build_request(**request_kwargs)
 
-    async def _execute_client_request(self, request: Request) -> Response:
-        """Execute a request through the injected ReflectAPI transport."""
-        response = await self._client.request(request)
-        if isinstance(response, httpx.Response):
-            return Response(
-                status=response.status_code,
-                headers=response.headers,
-                body=response.content,
-            )
-        return response
+    def _make_terminal(
+        self,
+        params: dict[str, Any] | None,
+    ) -> Callable[[Request], Awaitable[Response]]:
+        """Return the chain-terminal handler for the active transport.
 
-    async def _execute_request(self, request: httpx.Request) -> httpx.Response:
-        """Execute HTTP request through middleware chain."""
-        if self.middleware_chain.middleware:
-            return await self.middleware_chain.execute(request, self._client)
-        else:
-            return await self._client.send(request)
+        For an ``httpx.AsyncClient``, the terminal lifts the Request into
+        an ``httpx.Request``, sends it, and converts back. For a custom
+        :class:`AsyncClient`, the terminal calls ``client.request``
+        directly and trusts the structural shape of the returned response.
+        """
+        if isinstance(self._client, httpx.AsyncClient):
+            base_url = self.base_url
+
+            async def terminal(req: Request) -> Response:
+                url = f"{base_url}/{req.path.lstrip('/')}"
+                httpx_req = self._build_httpx_request(req, url, params)
+                httpx_resp = await self._client.send(httpx_req)
+                return Response(
+                    status=httpx_resp.status_code,
+                    headers=httpx_resp.headers,
+                    body=httpx_resp.content,
+                )
+
+            return terminal
+
+        async def terminal(req: Request) -> Response:
+            return await self._client.request(req)
+
+        return terminal
 
     def _handle_error_response(
         self,
@@ -1079,32 +1050,24 @@ class AsyncClientBase(ABC):
         # Validate request parameters
         self._validate_request_params(json_data, json_model)
 
+        # Build the transport request once and drive it through the
+        # middleware chain. The chain's terminal handler is transport-
+        # specific; middleware itself is transport-agnostic.
         request = self._build_client_request(
-            json_data, json_model, headers_model
+            path, json_data, json_model, headers_model
         )
-        request = Request(
-            path=path,
-            headers=request.headers,
-            body=request.body,
-        )
+        terminal = self._make_terminal(params)
 
         # Execute request with timing
         start_time = time.time()
 
         try:
-            if hasattr(self._client, "build_request") and hasattr(self._client, "send"):
-                url = f"{self.base_url}/{path.lstrip('/')}"
-                httpx_request = self._build_request(
-                    url, params, json_data, json_model, headers_model
-                )
-                response = await self._execute_request(httpx_request)
-            else:
-                client_response = await self._execute_client_request(request)
-                response = httpx.Response(
-                    status_code=client_response.status,
-                    headers=client_response.headers,
-                    content=client_response.body,
-                )
+            client_response = await self.middleware_chain.execute(request, terminal)
+            response = httpx.Response(
+                status_code=client_response.status,
+                headers=client_response.headers,
+                content=client_response.body,
+            )
             metadata = TransportMetadata.from_response(response, start_time)
 
             # Handle error responses
@@ -1150,9 +1113,10 @@ class AsyncClientBase(ABC):
         self._validate_request_params(json_data, json_model)
 
         url = f"{self.base_url}/{path.lstrip('/')}"
-        request = self._build_request(
-            url, params, json_data, json_model, headers_model
+        client_request = self._build_client_request(
+            path, json_data, json_model, headers_model
         )
+        request = self._build_httpx_request(client_request, url, params)
         request.headers["accept"] = "text/event-stream"
 
         start_time = time.time()

--- a/reflectapi-python-runtime/src/reflectapi_runtime/middleware.py
+++ b/reflectapi-python-runtime/src/reflectapi_runtime/middleware.py
@@ -1,4 +1,11 @@
-"""Middleware system for ReflectAPI Python clients."""
+"""Middleware system for ReflectAPI Python clients.
+
+Middleware operates on the transport-agnostic
+:class:`~reflectapi_runtime.transport.Request` /
+:class:`~reflectapi_runtime.transport.Response` shape, so the same
+middleware works whether the underlying transport is an ``httpx.Client``
+or a user-defined :class:`~reflectapi_runtime.transport.Client`.
+"""
 
 from __future__ import annotations
 
@@ -11,58 +18,72 @@ from typing import Union
 
 import httpx
 
+from .transport import Request, Response
+
 logger = logging.getLogger(__name__)
 
-# Type aliases for handlers in the middleware chain
-AsyncNextHandler = Callable[[httpx.Request], Awaitable[httpx.Response]]
-SyncNextHandler = Callable[[httpx.Request], httpx.Response]
+# Type aliases for the per-request handler chain.
+AsyncNextHandler = Callable[[Request], Awaitable[Response]]
+SyncNextHandler = Callable[[Request], Response]
 NextHandler = Union[AsyncNextHandler, SyncNextHandler]
 
 
 class AsyncMiddleware(ABC):
-    """Base class for asynchronous client middleware.
-
-    Middleware can intercept and transform requests and responses,
-    enabling cross-cutting concerns like caching, logging, retry logic, etc.
-    """
+    """Base class for asynchronous client middleware."""
 
     @abstractmethod
     async def handle(
-        self, request: httpx.Request, next_call: AsyncNextHandler
-    ) -> httpx.Response:
+        self, request: Request, next_call: AsyncNextHandler
+    ) -> Response:
         """Handle a request and return a response.
 
         Args:
-            request: The HTTP request to process
-            next_call: Async callable to continue the middleware chain
+            request: the transport request about to be sent.
+            next_call: invoke to continue the middleware chain.
 
         Returns:
-            The HTTP response (possibly modified)
+            The response to surface to the caller (possibly modified).
         """
-        pass
+        ...
 
 
 class SyncMiddleware(ABC):
-    """Base class for synchronous client middleware.
-
-    Middleware can intercept and transform requests and responses,
-    enabling cross-cutting concerns like caching, logging, retry logic, etc.
-    """
+    """Base class for synchronous client middleware."""
 
     @abstractmethod
     def handle(
-        self, request: httpx.Request, next_call: SyncNextHandler
-    ) -> httpx.Response:
+        self, request: Request, next_call: SyncNextHandler
+    ) -> Response:
         """Handle a request and return a response.
 
         Args:
-            request: The HTTP request to process
-            next_call: Callable to continue the middleware chain
-
-        Returns:
-            The HTTP response (possibly modified)
+            request: the transport request about to be sent.
+            next_call: invoke to continue the middleware chain.
         """
-        pass
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Built-in middleware
+# ---------------------------------------------------------------------------
+
+
+def _request_log_extra(request: Request) -> dict[str, object]:
+    return {
+        "path": request.path,
+        "headers": dict(request.headers),
+    }
+
+
+def _response_log_extra(
+    request: Request, response: Response
+) -> dict[str, object]:
+    return {
+        "status": response.status,
+        "path": request.path,
+        # Headers can be httpx.Headers or a dict — both behave like mappings.
+        "headers": dict(response.headers),
+    }
 
 
 class AsyncLoggingMiddleware(AsyncMiddleware):
@@ -72,29 +93,13 @@ class AsyncLoggingMiddleware(AsyncMiddleware):
         self.logger = logging.getLogger(logger_name)
 
     async def handle(
-        self, request: httpx.Request, next_call: AsyncNextHandler
-    ) -> httpx.Response:
-        """Log request and response details."""
-        self.logger.debug(
-            "Making request",
-            extra={
-                "method": request.method,
-                "url": str(request.url),
-                "headers": dict(request.headers),
-            },
-        )
-
+        self, request: Request, next_call: AsyncNextHandler
+    ) -> Response:
+        self.logger.debug("Making request", extra=_request_log_extra(request))
         response = await next_call(request)
-
         self.logger.debug(
-            "Received response",
-            extra={
-                "status_code": response.status_code,
-                "headers": dict(response.headers),
-                "url": str(request.url),
-            },
+            "Received response", extra=_response_log_extra(request, response)
         )
-
         return response
 
 
@@ -105,154 +110,149 @@ class SyncLoggingMiddleware(SyncMiddleware):
         self.logger = logging.getLogger(logger_name)
 
     def handle(
-        self, request: httpx.Request, next_call: SyncNextHandler
-    ) -> httpx.Response:
-        """Log request and response details."""
-        self.logger.debug(
-            "Making request",
-            extra={
-                "method": request.method,
-                "url": str(request.url),
-                "headers": dict(request.headers),
-            },
-        )
-
+        self, request: Request, next_call: SyncNextHandler
+    ) -> Response:
+        self.logger.debug("Making request", extra=_request_log_extra(request))
         response = next_call(request)
-
         self.logger.debug(
-            "Received response",
-            extra={
-                "status_code": response.status_code,
-                "headers": dict(response.headers),
-                "url": str(request.url),
-            },
+            "Received response", extra=_response_log_extra(request, response)
         )
-
         return response
 
 
 class RetryMiddleware(AsyncMiddleware):
-    """Middleware that retries requests on transient failures with exponential backoff and jitter."""
+    """Retry transient failures with exponential backoff and jitter.
 
-    # Methods that are safe to retry automatically on network failures
+    Retries on 4xx/5xx status codes from ``retry_status_codes`` and on any
+    exception of type ``retry_on`` raised by the downstream handler.
+    Defaults retry exceptions to ``httpx.RequestError`` so the existing
+    httpx-backed flow keeps working; users with custom transports can pass
+    their own exception types via ``retry_on``.
+    """
+
+    # Methods that are safe to retry automatically on network failures.
+    # Every reflectapi endpoint is POST, so by default we don't auto-retry
+    # network errors — callers can override via ``retry_non_idempotent``
+    # if their endpoints are known-safe.
     IDEMPOTENT_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "PUT", "DELETE", "TRACE"})
 
     def __init__(
         self,
         max_retries: int = 3,
         retry_status_codes: set[int] | None = None,
-        backoff_factor: float = 0.5,  # Start with a shorter backoff
+        backoff_factor: float = 0.5,
+        retry_on: tuple[type[BaseException], ...] = (httpx.RequestError,),
+        retry_non_idempotent: bool = False,
     ) -> None:
         self.max_retries = max_retries
         self.retry_status_codes = retry_status_codes or {429, 502, 503, 504}
         self.backoff_factor = backoff_factor
+        self.retry_on = retry_on
+        self.retry_non_idempotent = retry_non_idempotent
 
     async def handle(
-        self, request: httpx.Request, next_call: AsyncNextHandler
-    ) -> httpx.Response:
-        """Retry requests on transient failures."""
-        last_exception = None
+        self, request: Request, next_call: AsyncNextHandler
+    ) -> Response:
+        last_exception: BaseException | None = None
+        last_response: Response | None = None
 
         for attempt in range(self.max_retries + 1):
             try:
                 response = await next_call(request)
-
                 if (
                     attempt == self.max_retries
-                    or response.status_code not in self.retry_status_codes
+                    or response.status not in self.retry_status_codes
                 ):
                     return response
-
-                # If we are going to retry, store the response as the last exception
-                last_exception = response
-
-            except httpx.RequestError as e:
+                last_response = response
+            except self.retry_on as e:
                 last_exception = e
-                # Do not retry non-idempotent methods on network errors
+                # reflectapi is always POST; only retry on network errors
+                # if the caller has opted in.
                 if (
-                    request.method not in self.IDEMPOTENT_METHODS
+                    not self.retry_non_idempotent
                     or attempt == self.max_retries
                 ):
                     raise
 
-            # Backoff with Jitter (AWS-recommended approach)
-            # Cap the backoff at 30 seconds and add jitter for better distribution
-            temp = min(self.backoff_factor * (2**attempt), 30.0)  # Cap backoff
-            sleep_duration = temp / 2 + random.uniform(0, temp / 2)
-
+            # Exponential backoff with jitter, capped at 30s.
+            cap = min(self.backoff_factor * (2**attempt), 30.0)
+            sleep_duration = cap / 2 + random.uniform(0, cap / 2)
             logger.debug(
-                f"Retrying request to {request.url} after {sleep_duration:.2f}s (attempt {attempt + 1}/{self.max_retries})"
+                "Retrying %s after %.2fs (attempt %d/%d)",
+                request.path,
+                sleep_duration,
+                attempt + 1,
+                self.max_retries,
             )
             await asyncio.sleep(sleep_duration)
 
-        # This part should be unreachable, but linters might complain.
-        # It's better to re-raise the last known exception.
-        if isinstance(last_exception, httpx.Response):
-            return last_exception
-        raise last_exception from None
+        # Loop ended without an early return: surface whatever we last saw.
+        if last_response is not None:
+            return last_response
+        if last_exception is not None:
+            raise last_exception from None
+        # Unreachable: the loop body either returns, raises, or sets one of
+        # the two `last_*` slots before continuing.
+        raise RuntimeError("RetryMiddleware exhausted retries without an outcome")
+
+
+# ---------------------------------------------------------------------------
+# Middleware chains
+# ---------------------------------------------------------------------------
 
 
 class AsyncMiddlewareChain:
-    """Manages a chain of async middleware for processing requests."""
+    """Drive an async middleware list around a terminal handler."""
 
     def __init__(self, middleware: list[AsyncMiddleware]) -> None:
         self.middleware = middleware
 
     async def execute(
         self,
-        request: httpx.Request,
-        transport: httpx.AsyncClient,
-    ) -> httpx.Response:
-        """Execute the middleware chain with the given request."""
+        request: Request,
+        terminal: AsyncNextHandler,
+    ) -> Response:
+        """Run ``request`` through every middleware, ending in ``terminal``.
 
-        async def create_handler(
-            middleware_list: list[AsyncMiddleware], index: int
-        ) -> AsyncNextHandler:
-            """Create a handler for the middleware at the given index."""
+        ``terminal`` is the handler that actually performs the request —
+        the chain itself is transport-agnostic.
+        """
 
-            async def handler(req: httpx.Request) -> httpx.Response:
-                if index >= len(middleware_list):
-                    # End of chain - make the actual HTTP request
-                    return await transport.send(req)
-
-                # Process through next middleware
-                next_handler = await create_handler(middleware_list, index + 1)
-                return await middleware_list[index].handle(req, next_handler)
+        async def chain_at(index: int) -> AsyncNextHandler:
+            async def handler(req: Request) -> Response:
+                if index >= len(self.middleware):
+                    return await terminal(req)
+                next_handler = await chain_at(index + 1)
+                return await self.middleware[index].handle(req, next_handler)
 
             return handler
 
-        handler = await create_handler(self.middleware, 0)
+        handler = await chain_at(0)
         return await handler(request)
 
 
 class SyncMiddlewareChain:
-    """Manages a chain of sync middleware for processing requests."""
+    """Drive a sync middleware list around a terminal handler."""
 
     def __init__(self, middleware: list[SyncMiddleware]) -> None:
         self.middleware = middleware
 
     def execute(
         self,
-        request: httpx.Request,
-        transport: httpx.Client,
-    ) -> httpx.Response:
-        """Execute the middleware chain with the given request."""
+        request: Request,
+        terminal: SyncNextHandler,
+    ) -> Response:
+        """Run ``request`` through every middleware, ending in ``terminal``."""
 
-        def create_handler(
-            middleware_list: list[SyncMiddleware], index: int
-        ) -> SyncNextHandler:
-            """Create a handler for the middleware at the given index."""
-
-            def handler(req: httpx.Request) -> httpx.Response:
-                if index >= len(middleware_list):
-                    # End of chain - make the actual HTTP request
-                    return transport.send(req)
-
-                # Process through next middleware
-                next_handler = create_handler(middleware_list, index + 1)
-                return middleware_list[index].handle(req, next_handler)
+        def chain_at(index: int) -> SyncNextHandler:
+            def handler(req: Request) -> Response:
+                if index >= len(self.middleware):
+                    return terminal(req)
+                next_handler = chain_at(index + 1)
+                return self.middleware[index].handle(req, next_handler)
 
             return handler
 
-        handler = create_handler(self.middleware, 0)
+        handler = chain_at(0)
         return handler(request)

--- a/reflectapi-python-runtime/src/reflectapi_runtime/transport.py
+++ b/reflectapi-python-runtime/src/reflectapi_runtime/transport.py
@@ -1,0 +1,58 @@
+"""Transport-shape DTOs and Protocols shared by client and middleware.
+
+Lives in its own module so that ``middleware`` can depend on these types
+without creating a circular import with ``client``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class Request:
+    """Transport request passed to custom ReflectAPI Python clients.
+
+    ``method`` is intentionally absent: every reflectapi endpoint is POST
+    by design, so transports hardcode it. If that ever changes it's a
+    wire-protocol break and clients regenerate.
+    """
+
+    path: str
+    headers: dict[str, str]
+    body: bytes
+
+
+@dataclass(frozen=True)
+class Response:
+    """Transport response returned by custom ReflectAPI Python clients."""
+
+    status: int
+    # Permissive headers type so adapters wrapping httpx.Headers (which is
+    # case-insensitive) can hand it through verbatim instead of materialising
+    # a plain dict on the hot path.
+    headers: Any
+    body: bytes
+
+
+@runtime_checkable
+class Client(Protocol):
+    """Synchronous transport protocol for generated clients.
+
+    Implementations return any object with ``.status`` / ``.headers`` /
+    ``.body``; the provided :class:`Response` dataclass is a convenient
+    ready-made implementation, not a hard requirement.
+    """
+
+    def request(self, request: Request) -> Response: ...
+
+
+@runtime_checkable
+class AsyncClient(Protocol):
+    """Asynchronous transport protocol for generated clients.
+
+    See :class:`Client` for the structural-response contract.
+    """
+
+    async def request(self, request: Request) -> Response: ...

--- a/reflectapi-python-runtime/tests/test_client.py
+++ b/reflectapi-python-runtime/tests/test_client.py
@@ -206,7 +206,7 @@ class TestClientBase:
 
     def test_make_request_json_parse_error(self, mock_httpx_client):
         mock_client, mock_response = mock_httpx_client
-        mock_response.json.side_effect = ValueError("Invalid JSON")
+        mock_response.content = b"not valid json"
 
         client = ClientBase("http://example.com", client=mock_client)
 
@@ -259,7 +259,7 @@ class TestClientBase:
         mock_client, mock_response = mock_httpx_client
         mock_response.status_code = 500
         mock_response.reason_phrase = "Internal Server Error"
-        mock_response.json.side_effect = ValueError("Invalid JSON")
+        mock_response.content = b"not valid json"
 
         client = ClientBase("http://example.com", client=mock_client)
 
@@ -484,7 +484,7 @@ class TestAsyncClientBase:
         mock_client, mock_response = mock_async_httpx_client
         mock_response.status_code = 500
         mock_response.reason_phrase = "Internal Server Error"
-        mock_response.json.side_effect = ValueError("Invalid JSON")
+        mock_response.content = b"not valid json"
 
         client = AsyncClientBase("http://example.com", client=mock_client)
 

--- a/reflectapi-python-runtime/tests/test_edge_cases.py
+++ b/reflectapi-python-runtime/tests/test_edge_cases.py
@@ -89,6 +89,7 @@ class TestClientEdgeCases:
         mock_response.status_code = 200
         mock_response.json.return_value = {"result": "ok"}
         mock_response.headers = {}
+        mock_response.content = b'{"result": "ok"}'
         mock_response.elapsed.total_seconds.return_value = 0.1
         mock_send.return_value = mock_response
 
@@ -104,6 +105,7 @@ class TestClientEdgeCases:
         mock_response.status_code = 200
         mock_response.json.return_value = {"result": "ok"}
         mock_response.headers = {}
+        mock_response.content = b'{"result": "ok"}'
         mock_response.elapsed.total_seconds.return_value = 0.1
         mock_send.return_value = mock_response
 
@@ -131,6 +133,7 @@ class TestClientEdgeCases:
         mock_response.status_code = 200
         mock_response.json.return_value = {"result": "ok"}
         mock_response.headers = {}
+        mock_response.content = b'{"result": "ok"}'
         mock_response.elapsed.total_seconds.return_value = 0.1
         mock_send.return_value = mock_response
 
@@ -162,6 +165,7 @@ class TestAsyncClientEdgeCases:
             mock_response.status_code = 200
             mock_response.json.return_value = {"result": "ok"}
             mock_response.headers = {}
+            mock_response.content = b'{"result": "ok"}'
             mock_response.elapsed.total_seconds.return_value = 0.1
             mock_send.return_value = mock_response
 
@@ -272,6 +276,7 @@ class TestErrorHandlingEdgeCases:
         mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "doc", 0)
         mock_response.text = "Invalid JSON response"
         mock_response.headers = {}
+        mock_response.content = b'{"result": "ok"}'
         mock_response.elapsed.total_seconds.return_value = 0.1
         mock_send.return_value = mock_response
 
@@ -288,8 +293,10 @@ class TestErrorHandlingEdgeCases:
         """Test handling of invalid JSON in success response."""
         mock_response = Mock()
         mock_response.status_code = 200
-        mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "doc", 0)
         mock_response.headers = {}
+        # Real malformed bytes — runtime reconstructs httpx.Response and
+        # parses for real, so the failure surfaces from json() not the mock.
+        mock_response.content = b"not valid json"
         mock_response.elapsed.total_seconds.return_value = 0.1
         mock_send.return_value = mock_response
 
@@ -309,6 +316,7 @@ class TestErrorHandlingEdgeCases:
         mock_response.status_code = 500
         mock_response.json.return_value = large_error_data
         mock_response.headers = {}
+        mock_response.content = b'{"result": "ok"}'
         mock_response.elapsed.total_seconds.return_value = 0.1
         mock_send.return_value = mock_response
 
@@ -325,6 +333,7 @@ class TestErrorHandlingEdgeCases:
         mock_response = Mock()
         mock_response.status_code = 500
         mock_response.headers = {}
+        mock_response.content = b'{"result": "ok"}'
 
         metadata = TransportMetadata(
             status_code=500,
@@ -486,6 +495,7 @@ class TestConcurrencyEdgeCases:
                 mock_response.status_code = 200
                 mock_response.json.return_value = {"result": "ok"}
                 mock_response.headers = {}
+                mock_response.content = b'{"result": "ok"}'
                 mock_response.elapsed.total_seconds.return_value = 0.1
                 return mock_response
 
@@ -564,6 +574,7 @@ class TestTypeValidationEdgeCases:
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.headers = {}
+        mock_response.content = b'{"result": "ok"}'
 
         # Negative response time
         metadata = TransportMetadata(

--- a/reflectapi-python-runtime/tests/test_middleware.py
+++ b/reflectapi-python-runtime/tests/test_middleware.py
@@ -1,13 +1,14 @@
-"""Tests for middleware system."""
+"""Tests for the transport-agnostic middleware system."""
 
-import asyncio
+from __future__ import annotations
+
 import logging
-import time
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import patch
 
 import httpx
 import pytest
 
+from reflectapi_runtime import Request, Response
 from reflectapi_runtime.middleware import (
     AsyncLoggingMiddleware,
     AsyncMiddleware,
@@ -19,10 +20,45 @@ from reflectapi_runtime.middleware import (
 )
 
 
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_request(path: str = "/test", body: bytes = b"") -> Request:
+    return Request(
+        path=path, headers={"Authorization": "Bearer token"}, body=body
+    )
+
+
+def make_response(status: int = 200, body: bytes = b'{"ok": true}') -> Response:
+    return Response(
+        status=status,
+        headers={"Content-Type": "application/json"},
+        body=body,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Abstract base classes
+# ---------------------------------------------------------------------------
+
+
 class TestAsyncMiddleware:
     def test_is_abstract(self):
         with pytest.raises(TypeError):
-            AsyncMiddleware()
+            AsyncMiddleware()  # type: ignore[abstract]
+
+
+class TestSyncMiddleware:
+    def test_is_abstract(self):
+        with pytest.raises(TypeError):
+            SyncMiddleware()  # type: ignore[abstract]
+
+
+# ---------------------------------------------------------------------------
+# Logging middleware
+# ---------------------------------------------------------------------------
 
 
 class TestAsyncLoggingMiddleware:
@@ -36,503 +72,19 @@ class TestAsyncLoggingMiddleware:
     @pytest.mark.asyncio
     async def test_handle_logs_request_and_response(self, caplog):
         middleware = AsyncLoggingMiddleware()
+        request = make_request()
+        response = make_response()
 
-        mock_request = Mock(spec=httpx.Request)
-        mock_request.method = "GET"
-        mock_request.url = "http://example.com/test"
-        mock_request.headers = {"Authorization": "Bearer token"}
-
-        mock_response = Mock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.headers = {"Content-Type": "application/json"}
-
-        async def next_handler(request):
-            return mock_response
+        async def next_handler(req: Request) -> Response:
+            return response
 
         with caplog.at_level(logging.DEBUG):
-            result = await middleware.handle(mock_request, next_handler)
-
-        assert result is mock_response
-
-        log_messages = [record.message for record in caplog.records]
-        assert any("Making request" in msg for msg in log_messages)
-        assert any("Received response" in msg for msg in log_messages)
-
-
-class TestRetryMiddleware:
-    def test_initialization_defaults(self):
-        middleware = RetryMiddleware()
-
-        assert middleware.max_retries == 3
-        assert middleware.retry_status_codes == {429, 502, 503, 504}
-        assert middleware.backoff_factor == 0.5
-        assert (
-            frozenset({"GET", "HEAD", "OPTIONS", "PUT", "DELETE", "TRACE"})
-            == middleware.IDEMPOTENT_METHODS
-        )
-
-    def test_initialization_custom(self):
-        middleware = RetryMiddleware(
-            max_retries=5, retry_status_codes={400, 500}, backoff_factor=2.0
-        )
-
-        assert middleware.max_retries == 5
-        assert middleware.retry_status_codes == {400, 500}
-        assert middleware.backoff_factor == 2.0
-
-    @pytest.mark.asyncio
-    async def test_handle_successful_response(self):
-        middleware = RetryMiddleware()
-
-        mock_request = Mock(spec=httpx.Request)
-        mock_response = Mock(spec=httpx.Response)
-        mock_response.status_code = 200
-
-        call_count = 0
-
-        async def next_handler(request):
-            nonlocal call_count
-            call_count += 1
-            return mock_response
-
-        result = await middleware.handle(mock_request, next_handler)
-
-        assert result is mock_response
-        assert call_count == 1
-
-    @pytest.mark.asyncio
-    async def test_handle_non_retryable_error(self):
-        middleware = RetryMiddleware()
-
-        mock_request = Mock(spec=httpx.Request)
-        mock_response = Mock(spec=httpx.Response)
-        mock_response.status_code = 404
-
-        call_count = 0
-
-        async def next_handler(request):
-            nonlocal call_count
-            call_count += 1
-            return mock_response
-
-        result = await middleware.handle(mock_request, next_handler)
-
-        assert result is mock_response
-        assert call_count == 1
-
-    @pytest.mark.asyncio
-    async def test_handle_retryable_error_eventually_succeeds(self):
-        middleware = RetryMiddleware(max_retries=2, backoff_factor=0.01)
-
-        mock_request = Mock(spec=httpx.Request)
-        mock_request.url = "http://example.com/test"
-
-        call_count = 0
-
-        async def next_handler(request):
-            nonlocal call_count
-            call_count += 1
-
-            if call_count <= 2:
-                mock_response = Mock(spec=httpx.Response)
-                mock_response.status_code = 503  # Use default retry status code
-                return mock_response
-            else:
-                mock_response = Mock(spec=httpx.Response)
-                mock_response.status_code = 200
-                return mock_response
-
-        result = await middleware.handle(mock_request, next_handler)
-
-        assert result.status_code == 200
-        assert call_count == 3
-
-    @pytest.mark.asyncio
-    async def test_handle_retryable_error_exhausts_retries(self):
-        middleware = RetryMiddleware(max_retries=2, backoff_factor=0.01)
-
-        mock_request = Mock(spec=httpx.Request)
-        mock_request.url = "http://example.com/test"
-        mock_response = Mock(spec=httpx.Response)
-        mock_response.status_code = 503  # Use default retry status code
-
-        call_count = 0
-
-        async def next_handler(request):
-            nonlocal call_count
-            call_count += 1
-            return mock_response
-
-        result = await middleware.handle(mock_request, next_handler)
-
-        assert result.status_code == 503
-        assert call_count == 3
-
-    @pytest.mark.asyncio
-    async def test_handle_network_error_retries(self):
-        middleware = RetryMiddleware(max_retries=2, backoff_factor=0.01)
-
-        mock_request = Mock(spec=httpx.Request)
-        mock_request.method = "GET"  # Idempotent method
-        mock_request.url = "http://example.com/test"
-
-        call_count = 0
-
-        async def next_handler(request):
-            nonlocal call_count
-            call_count += 1
-
-            if call_count <= 2:
-                raise httpx.ConnectError("Connection failed")
-            else:
-                mock_response = Mock(spec=httpx.Response)
-                mock_response.status_code = 200
-                return mock_response
-
-        result = await middleware.handle(mock_request, next_handler)
-
-        assert result.status_code == 200
-        assert call_count == 3
-
-    @pytest.mark.asyncio
-    async def test_handle_network_error_exhausts_retries(self):
-        middleware = RetryMiddleware(max_retries=1, backoff_factor=0.01)
-
-        mock_request = Mock(spec=httpx.Request)
-        mock_request.method = "GET"  # Idempotent method
-        mock_request.url = "http://example.com/test"
-
-        async def next_handler(request):
-            raise httpx.ConnectError("Connection failed")
-
-        with pytest.raises(httpx.ConnectError):
-            await middleware.handle(mock_request, next_handler)
-
-    @pytest.mark.asyncio
-    async def test_idempotency_check_non_idempotent_methods(self):
-        """Test that non-idempotent methods are not retried on network errors."""
-        middleware = RetryMiddleware(max_retries=3, backoff_factor=0.01)
-
-        non_idempotent_methods = ["POST", "PATCH"]
-
-        for method in non_idempotent_methods:
-            mock_request = Mock(spec=httpx.Request)
-            mock_request.method = method
-            mock_request.url = "http://example.com/test"
-
-            call_count = 0
-
-            async def next_handler(request):
-                nonlocal call_count
-                call_count += 1
-                raise httpx.ConnectError("Connection failed")
-
-            with pytest.raises(httpx.ConnectError):
-                await middleware.handle(mock_request, next_handler)
-
-            # Should not retry non-idempotent methods on network errors
-            assert call_count == 1
-            call_count = 0  # Reset for next method
-
-    @pytest.mark.asyncio
-    async def test_idempotency_check_idempotent_methods(self):
-        """Test that idempotent methods are retried on network errors."""
-        middleware = RetryMiddleware(max_retries=2, backoff_factor=0.01)
-
-        idempotent_methods = ["GET", "HEAD", "OPTIONS", "PUT", "DELETE", "TRACE"]
-
-        for method in idempotent_methods:
-            mock_request = Mock(spec=httpx.Request)
-            mock_request.method = method
-            mock_request.url = "http://example.com/test"
-
-            call_count = 0
-
-            async def next_handler(request):
-                nonlocal call_count
-                call_count += 1
-                if call_count <= 2:
-                    raise httpx.ConnectError("Connection failed")
-                else:
-                    mock_response = Mock(spec=httpx.Response)
-                    mock_response.status_code = 200
-                    return mock_response
-
-            result = await middleware.handle(mock_request, next_handler)
-
-            # Should retry idempotent methods
-            assert result.status_code == 200
-            assert call_count == 3
-            call_count = 0  # Reset for next method
-
-    @pytest.mark.asyncio
-    async def test_rate_limit_retry_429(self):
-        """Test that 429 (rate limit) responses are retried."""
-        middleware = RetryMiddleware(max_retries=2, backoff_factor=0.01)
-
-        mock_request = Mock(spec=httpx.Request)
-        mock_request.method = "POST"  # Non-idempotent, but should retry on 429
-        mock_request.url = "http://example.com/test"
-
-        call_count = 0
-
-        async def next_handler(request):
-            nonlocal call_count
-            call_count += 1
-            if call_count <= 2:
-                mock_response = Mock(spec=httpx.Response)
-                mock_response.status_code = 429
-                return mock_response
-            else:
-                mock_response = Mock(spec=httpx.Response)
-                mock_response.status_code = 200
-                return mock_response
-
-        result = await middleware.handle(mock_request, next_handler)
-
-        assert result.status_code == 200
-        assert call_count == 3
-
-    @pytest.mark.asyncio
-    async def test_exponential_backoff_with_jitter(self):
-        """Test that backoff timing follows exponential pattern with jitter."""
-        middleware = RetryMiddleware(max_retries=3, backoff_factor=1.0)
-
-        mock_request = Mock(spec=httpx.Request)
-        mock_request.url = "http://example.com/test"
-        mock_response = Mock(spec=httpx.Response)
-        mock_response.status_code = 503
-
-        sleep_times = []
-        original_sleep = asyncio.sleep
-
-        async def mock_sleep(duration):
-            sleep_times.append(duration)
-            # Use a very short sleep for testing
-            await original_sleep(0.001)
-
-        async def next_handler(request):
-            return mock_response
-
-        with patch("asyncio.sleep", side_effect=mock_sleep):
-            result = await middleware.handle(mock_request, next_handler)
-
-        # Should have 3 sleep calls (for 3 retry attempts)
-        assert len(sleep_times) == 3
-
-        # Verify exponential backoff pattern (with jitter, so approximate)
-        # With backoff_factor=1.0: base delays are 1.0, 2.0, 4.0
-        # AWS-style jitter: temp/2 + random(0, temp/2) where temp = min(base, 30)
-        # So ranges are: 0.5-1.0, 1.0-2.0, 2.0-4.0
-        assert 0.5 <= sleep_times[0] <= 1.0
-        assert 1.0 <= sleep_times[1] <= 2.0
-        assert 2.0 <= sleep_times[2] <= 4.0
-
-        assert result.status_code == 503
-
-    @pytest.mark.asyncio
-    async def test_backoff_cap_at_30_seconds(self):
-        """Test that backoff is capped at 30 seconds."""
-        middleware = RetryMiddleware(max_retries=10, backoff_factor=2.0)
-
-        mock_request = Mock(spec=httpx.Request)
-        mock_request.url = "http://example.com/test"
-        mock_response = Mock(spec=httpx.Response)
-        mock_response.status_code = 503
-
-        sleep_times = []
-        original_sleep = asyncio.sleep
-
-        async def mock_sleep(duration):
-            sleep_times.append(duration)
-            await original_sleep(0.001)
-
-        async def next_handler(request):
-            return mock_response
-
-        with patch("asyncio.sleep", side_effect=mock_sleep):
-            await middleware.handle(mock_request, next_handler)
-
-        # All sleep times should be <= 30 seconds (with jitter, max is 30)
-        for sleep_time in sleep_times:
-            assert sleep_time <= 30.0
-
-        # Later attempts should be capped
-        assert max(sleep_times[-3:]) <= 30.0
-
-    @pytest.mark.asyncio
-    async def test_retry_logging(self, caplog):
-        """Test that retry attempts are logged with proper details."""
-        middleware = RetryMiddleware(max_retries=2, backoff_factor=0.01)
-
-        mock_request = Mock(spec=httpx.Request)
-        mock_request.url = "http://example.com/test"
-        mock_response = Mock(spec=httpx.Response)
-        mock_response.status_code = 503
-
-        async def next_handler(request):
-            return mock_response
-
-        with caplog.at_level(logging.DEBUG):
-            await middleware.handle(mock_request, next_handler)
-
-        # Should log retry attempts
-        log_messages = [record.message for record in caplog.records]
-        retry_logs = [msg for msg in log_messages if "Retrying request" in msg]
-
-        assert len(retry_logs) == 2  # 2 retry attempts
-        assert "http://example.com/test" in retry_logs[0]
-        assert "attempt 1/2" in retry_logs[0]
-        assert "attempt 2/2" in retry_logs[1]
-
-    @pytest.mark.asyncio
-    async def test_custom_retry_status_codes(self):
-        """Test retry behavior with custom status codes."""
-        middleware = RetryMiddleware(
-            max_retries=2,
-            retry_status_codes={418, 420},  # Custom status codes
-            backoff_factor=0.01,
-        )
-
-        mock_request = Mock(spec=httpx.Request)
-        mock_request.url = "http://example.com/test"
-
-        # Test that custom status code is retried
-        call_count = 0
-
-        async def next_handler_custom(request):
-            nonlocal call_count
-            call_count += 1
-            if call_count <= 2:
-                mock_response = Mock(spec=httpx.Response)
-                mock_response.status_code = 418  # Custom retry code
-                return mock_response
-            else:
-                mock_response = Mock(spec=httpx.Response)
-                mock_response.status_code = 200
-                return mock_response
-
-        result = await middleware.handle(mock_request, next_handler_custom)
-        assert result.status_code == 200
-        assert call_count == 3
-
-        # Test that default retry codes are not retried
-        call_count = 0
-
-        async def next_handler_default(request):
-            nonlocal call_count
-            call_count += 1
-            mock_response = Mock(spec=httpx.Response)
-            mock_response.status_code = 503  # Default retry code, but not in custom set
-            return mock_response
-
-        result = await middleware.handle(mock_request, next_handler_default)
-        assert result.status_code == 503
-        assert call_count == 1  # No retries
-
-
-class TestAsyncMiddlewareChain:
-    def test_initialization(self):
-        middleware1 = AsyncLoggingMiddleware()
-        middleware2 = RetryMiddleware()
-
-        chain = AsyncMiddlewareChain([middleware1, middleware2])
-
-        assert len(chain.middleware) == 2
-        assert chain.middleware[0] is middleware1
-        assert chain.middleware[1] is middleware2
-
-    @pytest.mark.asyncio
-    async def test_execute_empty_chain(self):
-        chain = AsyncMiddlewareChain([])
-
-        mock_request = Mock(spec=httpx.Request)
-        mock_response = Mock(spec=httpx.Response)
-
-        mock_transport = AsyncMock()
-        mock_transport.send.return_value = mock_response
-
-        result = await chain.execute(mock_request, mock_transport)
-
-        assert result is mock_response
-        mock_transport.send.assert_called_once_with(mock_request)
-
-    @pytest.mark.asyncio
-    async def test_execute_single_middleware(self):
-        middleware = AsyncLoggingMiddleware()
-        chain = AsyncMiddlewareChain([middleware])
-
-        mock_request = Mock(spec=httpx.Request)
-        mock_request.method = "GET"
-        mock_request.url = "http://example.com"
-        mock_request.headers = {}
-
-        mock_response = Mock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.headers = {}
-
-        mock_transport = AsyncMock()
-        mock_transport.send.return_value = mock_response
-
-        result = await chain.execute(mock_request, mock_transport)
-
-        assert result is mock_response
-        mock_transport.send.assert_called_once_with(mock_request)
-
-    @pytest.mark.asyncio
-    async def test_execute_multiple_middleware(self):
-        """Test middleware chain execution order with response modification."""
-
-        class TestMiddleware1(AsyncMiddleware):
-            async def handle(self, request, next_call):
-                response = await next_call(request)
-                response.test_attr1 = "middleware1"
-                return response
-
-        class TestMiddleware2(AsyncMiddleware):
-            async def handle(self, request, next_call):
-                response = await next_call(request)
-                response.test_attr2 = "middleware2"
-                return response
-
-        middleware1 = TestMiddleware1()
-        middleware2 = TestMiddleware2()
-        chain = AsyncMiddlewareChain([middleware1, middleware2])
-
-        mock_request = Mock(spec=httpx.Request)
-        mock_response = Mock(spec=httpx.Response)
-
-        mock_transport = AsyncMock()
-        mock_transport.send.return_value = mock_response
-
-        result = await chain.execute(mock_request, mock_transport)
-
-        assert result is mock_response
-        assert hasattr(result, "test_attr1")
-        assert hasattr(result, "test_attr2")
-        assert result.test_attr1 == "middleware1"
-        assert result.test_attr2 == "middleware2"
-
-    @pytest.mark.asyncio
-    async def test_execute_with_async_client(self):
-        chain = AsyncMiddlewareChain([])
-
-        mock_request = Mock(spec=httpx.Request)
-        mock_response = Mock(spec=httpx.Response)
-
-        mock_client = AsyncMock(spec=httpx.AsyncClient)
-        mock_client.send.return_value = mock_response
-
-        result = await chain.execute(mock_request, mock_client)
-
-        assert result is mock_response
-        mock_client.send.assert_called_once_with(mock_request)
-
-
-class TestSyncMiddleware:
-    def test_is_abstract(self):
-        with pytest.raises(TypeError):
-            SyncMiddleware()
+            result = await middleware.handle(request, next_handler)
+
+        assert result is response
+        messages = [record.message for record in caplog.records]
+        assert any("Making request" in m for m in messages)
+        assert any("Received response" in m for m in messages)
 
 
 class TestSyncLoggingMiddleware:
@@ -540,165 +92,396 @@ class TestSyncLoggingMiddleware:
         middleware = SyncLoggingMiddleware()
         assert middleware.logger.name == "reflectapi.client"
 
-        middleware = SyncLoggingMiddleware("custom.logger")
-        assert middleware.logger.name == "custom.logger"
-
     def test_handle_logs_request_and_response(self, caplog):
         middleware = SyncLoggingMiddleware()
+        request = make_request()
+        response = make_response()
 
-        mock_request = Mock(spec=httpx.Request)
-        mock_request.method = "GET"
-        mock_request.url = "http://example.com/test"
-        mock_request.headers = {"Authorization": "Bearer token"}
-
-        mock_response = Mock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.headers = {"Content-Type": "application/json"}
-
-        def next_handler(request):
-            return mock_response
+        def next_handler(req: Request) -> Response:
+            return response
 
         with caplog.at_level(logging.DEBUG):
-            result = middleware.handle(mock_request, next_handler)
+            result = middleware.handle(request, next_handler)
 
-        assert result is mock_response
+        assert result is response
+        messages = [record.message for record in caplog.records]
+        assert any("Making request" in m for m in messages)
+        assert any("Received response" in m for m in messages)
 
-        log_messages = [record.message for record in caplog.records]
-        assert any("Making request" in msg for msg in log_messages)
-        assert any("Received response" in msg for msg in log_messages)
+
+# ---------------------------------------------------------------------------
+# Retry middleware
+# ---------------------------------------------------------------------------
+
+
+class TestRetryMiddleware:
+    def test_initialization_defaults(self):
+        middleware = RetryMiddleware()
+        assert middleware.max_retries == 3
+        assert middleware.retry_status_codes == {429, 502, 503, 504}
+        assert middleware.backoff_factor == 0.5
+        assert middleware.retry_on == (httpx.RequestError,)
+        assert middleware.retry_non_idempotent is False
+
+    def test_initialization_custom(self):
+        middleware = RetryMiddleware(
+            max_retries=5,
+            retry_status_codes={400, 500},
+            backoff_factor=2.0,
+            retry_on=(IOError,),
+            retry_non_idempotent=True,
+        )
+        assert middleware.max_retries == 5
+        assert middleware.retry_status_codes == {400, 500}
+        assert middleware.backoff_factor == 2.0
+        assert middleware.retry_on == (IOError,)
+        assert middleware.retry_non_idempotent is True
+
+    @pytest.mark.asyncio
+    async def test_handle_successful_response(self):
+        middleware = RetryMiddleware()
+        request = make_request()
+        response = make_response(status=200)
+
+        calls = 0
+
+        async def next_handler(req):
+            nonlocal calls
+            calls += 1
+            return response
+
+        result = await middleware.handle(request, next_handler)
+        assert result is response
+        assert calls == 1
+
+    @pytest.mark.asyncio
+    async def test_handle_non_retryable_status_returned_immediately(self):
+        middleware = RetryMiddleware()
+        request = make_request()
+        response = make_response(status=400)
+
+        calls = 0
+
+        async def next_handler(req):
+            nonlocal calls
+            calls += 1
+            return response
+
+        result = await middleware.handle(request, next_handler)
+        assert result is response
+        assert calls == 1
+
+    @pytest.mark.asyncio
+    async def test_handle_retryable_status_eventually_succeeds(self):
+        middleware = RetryMiddleware(max_retries=3, backoff_factor=0)
+        request = make_request()
+        responses = [
+            make_response(status=503),
+            make_response(status=503),
+            make_response(status=200),
+        ]
+        calls = iter(responses)
+
+        async def next_handler(req):
+            return next(calls)
+
+        with patch("asyncio.sleep") as sleep:
+            result = await middleware.handle(request, next_handler)
+
+        assert result.status == 200
+        assert sleep.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_handle_retryable_status_exhausts_retries(self):
+        middleware = RetryMiddleware(max_retries=2, backoff_factor=0)
+        request = make_request()
+        response = make_response(status=503)
+
+        calls = 0
+
+        async def next_handler(req):
+            nonlocal calls
+            calls += 1
+            return response
+
+        with patch("asyncio.sleep"):
+            result = await middleware.handle(request, next_handler)
+
+        assert result.status == 503
+        assert calls == 3  # initial + 2 retries
+
+    @pytest.mark.asyncio
+    async def test_default_post_does_not_retry_network_error(self):
+        # reflectapi is always POST; default behaviour does not auto-retry
+        # network errors because POST is not idempotent in general.
+        middleware = RetryMiddleware(max_retries=3, backoff_factor=0)
+        request = make_request()
+
+        calls = 0
+
+        async def next_handler(req):
+            nonlocal calls
+            calls += 1
+            raise httpx.ConnectError("boom")
+
+        with pytest.raises(httpx.ConnectError):
+            await middleware.handle(request, next_handler)
+        assert calls == 1
+
+    @pytest.mark.asyncio
+    async def test_retry_non_idempotent_opts_in(self):
+        middleware = RetryMiddleware(
+            max_retries=2, backoff_factor=0, retry_non_idempotent=True
+        )
+        request = make_request()
+        success = make_response(status=200)
+
+        calls = 0
+
+        async def next_handler(req):
+            nonlocal calls
+            calls += 1
+            if calls < 2:
+                raise httpx.ConnectError("boom")
+            return success
+
+        with patch("asyncio.sleep"):
+            result = await middleware.handle(request, next_handler)
+
+        assert result is success
+        assert calls == 2
+
+    @pytest.mark.asyncio
+    async def test_custom_retry_on_exception(self):
+        """Users can configure non-httpx exception types via retry_on."""
+
+        class _CustomTransportError(Exception):
+            pass
+
+        middleware = RetryMiddleware(
+            max_retries=2,
+            backoff_factor=0,
+            retry_on=(_CustomTransportError,),
+            retry_non_idempotent=True,
+        )
+        request = make_request()
+        success = make_response(status=200)
+
+        calls = 0
+
+        async def next_handler(req):
+            nonlocal calls
+            calls += 1
+            if calls < 2:
+                raise _CustomTransportError("boom")
+            return success
+
+        with patch("asyncio.sleep"):
+            result = await middleware.handle(request, next_handler)
+
+        assert result is success
+        assert calls == 2
+
+    @pytest.mark.asyncio
+    async def test_429_retried_by_default(self):
+        middleware = RetryMiddleware(max_retries=2, backoff_factor=0)
+        request = make_request()
+        responses = [make_response(status=429), make_response(status=200)]
+        calls = iter(responses)
+
+        async def next_handler(req):
+            return next(calls)
+
+        with patch("asyncio.sleep"):
+            result = await middleware.handle(request, next_handler)
+        assert result.status == 200
+
+    @pytest.mark.asyncio
+    async def test_custom_retry_status_codes(self):
+        middleware = RetryMiddleware(
+            max_retries=2, retry_status_codes={418}, backoff_factor=0
+        )
+        request = make_request()
+        response = make_response(status=503)
+
+        calls = 0
+
+        async def next_handler(req):
+            nonlocal calls
+            calls += 1
+            return response
+
+        result = await middleware.handle(request, next_handler)
+        assert result.status == 503
+        assert calls == 1
+
+    @pytest.mark.asyncio
+    async def test_exponential_backoff_is_capped(self):
+        middleware = RetryMiddleware(max_retries=4, backoff_factor=100.0)
+        request = make_request()
+        response = make_response(status=503)
+
+        async def next_handler(req):
+            return response
+
+        sleeps: list[float] = []
+
+        async def fake_sleep(seconds):
+            sleeps.append(seconds)
+
+        with patch("asyncio.sleep", side_effect=fake_sleep):
+            await middleware.handle(request, next_handler)
+
+        assert sleeps, "expected at least one backoff sleep"
+        assert all(s <= 30.0 for s in sleeps)
+
+
+# ---------------------------------------------------------------------------
+# Middleware chains — terminal handler is now an arbitrary callable.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingAsyncMiddleware(AsyncMiddleware):
+    def __init__(self, name: str, log: list[str]) -> None:
+        self.name = name
+        self.log = log
+
+    async def handle(self, request, next_call):
+        self.log.append(f"{self.name}:before")
+        response = await next_call(request)
+        self.log.append(f"{self.name}:after")
+        return response
+
+
+class _RecordingSyncMiddleware(SyncMiddleware):
+    def __init__(self, name: str, log: list[str]) -> None:
+        self.name = name
+        self.log = log
+
+    def handle(self, request, next_call):
+        self.log.append(f"{self.name}:before")
+        response = next_call(request)
+        self.log.append(f"{self.name}:after")
+        return response
+
+
+class TestAsyncMiddlewareChain:
+    def test_initialization(self):
+        chain = AsyncMiddlewareChain([])
+        assert chain.middleware == []
+
+    @pytest.mark.asyncio
+    async def test_execute_empty_chain_calls_terminal(self):
+        chain = AsyncMiddlewareChain([])
+        request = make_request()
+        response = make_response()
+        terminal_calls = 0
+
+        async def terminal(req: Request) -> Response:
+            nonlocal terminal_calls
+            terminal_calls += 1
+            assert req is request
+            return response
+
+        result = await chain.execute(request, terminal)
+        assert result is response
+        assert terminal_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_execute_runs_middleware_around_terminal(self):
+        log: list[str] = []
+        chain = AsyncMiddlewareChain([_RecordingAsyncMiddleware("m1", log)])
+        request = make_request()
+        response = make_response()
+
+        async def terminal(req):
+            log.append("terminal")
+            return response
+
+        result = await chain.execute(request, terminal)
+        assert result is response
+        assert log == ["m1:before", "terminal", "m1:after"]
+
+    @pytest.mark.asyncio
+    async def test_execute_preserves_middleware_ordering(self):
+        log: list[str] = []
+        chain = AsyncMiddlewareChain(
+            [
+                _RecordingAsyncMiddleware("outer", log),
+                _RecordingAsyncMiddleware("inner", log),
+            ]
+        )
+        request = make_request()
+        response = make_response()
+
+        async def terminal(req):
+            log.append("terminal")
+            return response
+
+        await chain.execute(request, terminal)
+        assert log == [
+            "outer:before",
+            "inner:before",
+            "terminal",
+            "inner:after",
+            "outer:after",
+        ]
 
 
 class TestSyncMiddlewareChain:
     def test_initialization(self):
-        middleware1 = SyncLoggingMiddleware()
-        middleware2 = SyncLoggingMiddleware("custom")
-
-        chain = SyncMiddlewareChain([middleware1, middleware2])
-
-        assert len(chain.middleware) == 2
-        assert chain.middleware[0] is middleware1
-        assert chain.middleware[1] is middleware2
-
-    def test_execute_empty_chain(self):
         chain = SyncMiddlewareChain([])
+        assert chain.middleware == []
 
-        mock_request = Mock(spec=httpx.Request)
-        mock_response = Mock(spec=httpx.Response)
-
-        mock_transport = Mock(spec=httpx.Client)
-        mock_transport.send.return_value = mock_response
-
-        result = chain.execute(mock_request, mock_transport)
-
-        assert result is mock_response
-        mock_transport.send.assert_called_once_with(mock_request)
-
-    def test_execute_single_middleware(self):
-        middleware = SyncLoggingMiddleware()
-        chain = SyncMiddlewareChain([middleware])
-
-        mock_request = Mock(spec=httpx.Request)
-        mock_request.method = "GET"
-        mock_request.url = "http://example.com"
-        mock_request.headers = {}
-
-        mock_response = Mock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.headers = {}
-
-        mock_transport = Mock(spec=httpx.Client)
-        mock_transport.send.return_value = mock_response
-
-        result = chain.execute(mock_request, mock_transport)
-
-        assert result is mock_response
-        mock_transport.send.assert_called_once_with(mock_request)
-
-    def test_execute_multiple_middleware(self):
-        class TestSyncMiddleware1(SyncMiddleware):
-            def handle(self, request, next_call):
-                response = next_call(request)
-                response.test_attr1 = "sync_middleware1"
-                return response
-
-        class TestSyncMiddleware2(SyncMiddleware):
-            def handle(self, request, next_call):
-                response = next_call(request)
-                response.test_attr2 = "sync_middleware2"
-                return response
-
-        middleware1 = TestSyncMiddleware1()
-        middleware2 = TestSyncMiddleware2()
-        chain = SyncMiddlewareChain([middleware1, middleware2])
-
-        mock_request = Mock(spec=httpx.Request)
-        mock_response = Mock(spec=httpx.Response)
-
-        mock_transport = Mock(spec=httpx.Client)
-        mock_transport.send.return_value = mock_response
-
-        result = chain.execute(mock_request, mock_transport)
-
-        assert result is mock_response
-        assert hasattr(result, "test_attr1")
-        assert hasattr(result, "test_attr2")
-        assert result.test_attr1 == "sync_middleware1"
-        assert result.test_attr2 == "sync_middleware2"
-
-    def test_execute_with_sync_client(self):
+    def test_execute_empty_chain_calls_terminal(self):
         chain = SyncMiddlewareChain([])
+        request = make_request()
+        response = make_response()
+        terminal_calls = 0
 
-        mock_request = Mock(spec=httpx.Request)
-        mock_response = Mock(spec=httpx.Response)
+        def terminal(req):
+            nonlocal terminal_calls
+            terminal_calls += 1
+            return response
 
-        mock_client = Mock(spec=httpx.Client)
-        mock_client.send.return_value = mock_response
+        result = chain.execute(request, terminal)
+        assert result is response
+        assert terminal_calls == 1
 
-        result = chain.execute(mock_request, mock_client)
+    def test_execute_runs_middleware_around_terminal(self):
+        log: list[str] = []
+        chain = SyncMiddlewareChain([_RecordingSyncMiddleware("m1", log)])
+        request = make_request()
+        response = make_response()
 
-        assert result is mock_response
-        mock_client.send.assert_called_once_with(mock_request)
+        def terminal(req):
+            log.append("terminal")
+            return response
 
-    def test_sync_middleware_execution_order(self):
-        """Test middleware execution order follows onion pattern."""
-        execution_order = []
+        result = chain.execute(request, terminal)
+        assert result is response
+        assert log == ["m1:before", "terminal", "m1:after"]
 
-        class OrderTestMiddleware1(SyncMiddleware):
-            def handle(self, request, next_call):
-                execution_order.append("middleware1_before")
-                response = next_call(request)
-                execution_order.append("middleware1_after")
-                return response
+    def test_execute_preserves_middleware_ordering(self):
+        log: list[str] = []
+        chain = SyncMiddlewareChain(
+            [
+                _RecordingSyncMiddleware("outer", log),
+                _RecordingSyncMiddleware("inner", log),
+            ]
+        )
+        request = make_request()
+        response = make_response()
 
-        class OrderTestMiddleware2(SyncMiddleware):
-            def handle(self, request, next_call):
-                execution_order.append("middleware2_before")
-                response = next_call(request)
-                execution_order.append("middleware2_after")
-                return response
+        def terminal(req):
+            log.append("terminal")
+            return response
 
-        middleware1 = OrderTestMiddleware1()
-        middleware2 = OrderTestMiddleware2()
-        chain = SyncMiddlewareChain([middleware1, middleware2])
-
-        mock_request = Mock(spec=httpx.Request)
-        mock_response = Mock(spec=httpx.Response)
-
-        def mock_transport_send(request):
-            execution_order.append("transport_send")
-            return mock_response
-
-        mock_transport = Mock(spec=httpx.Client)
-        mock_transport.send = mock_transport_send
-
-        result = chain.execute(mock_request, mock_transport)
-
-        assert result is mock_response
-        expected_order = [
-            "middleware1_before",
-            "middleware2_before",
-            "transport_send",
-            "middleware2_after",
-            "middleware1_after",
+        chain.execute(request, terminal)
+        assert log == [
+            "outer:before",
+            "inner:before",
+            "terminal",
+            "inner:after",
+            "outer:after",
         ]
-        assert execution_order == expected_order


### PR DESCRIPTION
Follow-up to #137 with the five concerns from review. Targets `client-request-response-shape` so the diff is small; rebase target switches to `main` once #137 lands.

## What changes

1. **Single `ClientRequest` build per request.** `_build_client_request` takes `path` directly. `_build_request` (which silently rebuilt the DTO) is replaced by `_build_httpx_request`, which only lifts an existing `ClientRequest` into an `httpx.Request`.

2. **Middleware now operates on `ClientRequest` / `ClientResponse`.** The chain wraps an arbitrary terminal handler, so the same middleware runs against either an `httpx.Client` or a custom `Client` transport. `RetryMiddleware` gains a `retry_on` parameter so non-httpx transports can configure their own retryable exception types; the default keeps `httpx.RequestError` for backward compat. The construction-time `UserWarning` from a previous draft is gone.

3. **Drop the `isinstance(ClientResponse)` check on custom-transport responses.** Symmetric with the structural `Client` / `AsyncClient` input Protocols — anything with `.status` / `.headers` / `.body` works. The dataclass remains as a convenient ready-made implementation.

4. **`isinstance(httpx.(Async)Client)` dispatch** instead of duck-typing on `build_request` / `send` names.

5. **Move `ClientRequest` / `ClientResponse` / `Client` / `AsyncClient` to `transport.py`** so `middleware.py` can depend on the types without a circular import via `client.py`.

## Tests

- New `TestSingleClientRequestBuild` and `TestMiddlewareRunsOnBothTransports` and `TestDispatchUsesIsinstanceHttpxClient` in `test_client.py` pin the new contract on both transports.
- `test_middleware.py` rewritten against the `ClientRequest` / `ClientResponse` contract — smaller, fewer mocks, retains coverage of logging, retry (status, idempotent vs non-idempotent network errors, custom retry_on, backoff cap), and chain ordering.
- `test_pydantic_serialization.py` / `test_edge_cases.py` updated where mocks relied on `.json` side-effects or unset `.content`; the runtime reconstructs `httpx.Response` from the `ClientResponse` bytes, so parse failures need real malformed bytes rather than mock injection.

All 370 runtime tests pass; Rust workspace clean.

## Note on "I assume the protocol means anything that implements what we need is accepted?"

Yes — that was the missing principle. The original draft had `isinstance(ClientResponse)` on the response, which contradicted the Protocol-based input contract. Fixed in (3) above.