### PR TITLE
chore: 0.17.2-alpha.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi"
-version = "0.17.2-alpha.2"
+version = "0.17.2-alpha.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi-cli"
-version = "0.17.2-alpha.2"
+version = "0.17.2-alpha.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi-derive"
-version = "0.17.2-alpha.2"
+version = "0.17.2-alpha.3"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi-schema"
-version = "0.17.2-alpha.2"
+version = "0.17.2-alpha.3"
 dependencies = [
  "glob",
  "serde",

--- a/reflectapi-cli/Cargo.toml
+++ b/reflectapi-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi-cli"
-version = "0.17.2-alpha.2"
+version = "0.17.2-alpha.3"
 edition = "2021"
 default-run = "reflectapi"
 
@@ -23,7 +23,7 @@ doc = false
 workspace = true
 
 [dependencies]
-reflectapi = { path = "../reflectapi", version = "0.17.2-alpha.2", features = ["codegen"] }
+reflectapi = { path = "../reflectapi", version = "0.17.2-alpha.3", features = ["codegen"] }
 rouille = "3"
 
 clap = { version = "4.5.3", features = ["derive"] }

--- a/reflectapi-derive/Cargo.toml
+++ b/reflectapi-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi-derive"
-version = "0.17.2-alpha.2"
+version = "0.17.2-alpha.3"
 edition = "2021"
 
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ workspace = true
 proc-macro = true
 
 [dependencies]
-reflectapi-schema = { path = '../reflectapi-schema', version = "0.17.2-alpha.2" }
+reflectapi-schema = { path = '../reflectapi-schema', version = "0.17.2-alpha.3" }
 
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/reflectapi-python-runtime/pyproject.toml
+++ b/reflectapi-python-runtime/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "reflectapi-runtime"
-version = "0.17.2a2"
+version = "0.17.2a3"
 description = "Runtime library for ReflectAPI Python clients"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/reflectapi-python-runtime/src/reflectapi_runtime/__init__.py
+++ b/reflectapi-python-runtime/src/reflectapi_runtime/__init__.py
@@ -56,7 +56,7 @@ from .testing import (
 )
 from .types import BatchResult, ReflectapiEmpty, ReflectapiInfallible
 
-__version__ = "0.17.2a2"
+__version__ = "0.17.2a3"
 
 __all__ = [
     # Authentication

--- a/reflectapi-schema/Cargo.toml
+++ b/reflectapi-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi-schema"
-version = "0.17.2-alpha.2"
+version = "0.17.2-alpha.3"
 edition = "2021"
 
 license = "Apache-2.0"

--- a/reflectapi/Cargo.toml
+++ b/reflectapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi"
-version = "0.17.2-alpha.2"
+version = "0.17.2-alpha.3"
 edition = "2021"
 
 license = "Apache-2.0"
@@ -20,8 +20,8 @@ workspace = true
 
 [dependencies]
 # workspace dependencies
-reflectapi-derive = { path = "../reflectapi-derive", version = "0.17.2-alpha.2" }
-reflectapi-schema = { path = "../reflectapi-schema", version = "0.17.2-alpha.2" }
+reflectapi-derive = { path = "../reflectapi-derive", version = "0.17.2-alpha.3" }
+reflectapi-schema = { path = "../reflectapi-schema", version = "0.17.2-alpha.3" }
 
 # mandatory 3rd party dependencies
 serde = { version = "1.0.197", features = ["derive"] }


### PR DESCRIPTION
Alpha release validating the transport-shape refactor (#137, #141, #140).

## Summary
- Bumps all 4 Cargo crates from 0.17.2-alpha.2 → 0.17.2-alpha.3
- Bumps reflectapi-python-runtime from 0.17.2a2 → 0.17.2a3

## Test plan
- [ ] CI green
- [ ] After merge, tag v0.17.2-alpha.3 to trigger release workflow
- [ ] Verify Trusted Publishing succeeds for crates.io and PyPI