### PR TITLE
chore: 0.17.3-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.17.3-alpha.1
 
 ### Python — partial fields without a wrapper class
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi"
-version = "0.17.2"
+version = "0.17.3-alpha.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi-cli"
-version = "0.17.2"
+version = "0.17.3-alpha.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi-derive"
-version = "0.17.2"
+version = "0.17.3-alpha.1"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi-schema"
-version = "0.17.2"
+version = "0.17.3-alpha.1"
 dependencies = [
  "glob",
  "serde",

--- a/reflectapi-cli/Cargo.toml
+++ b/reflectapi-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi-cli"
-version = "0.17.2"
+version = "0.17.3-alpha.1"
 edition = "2021"
 default-run = "reflectapi"
 
@@ -23,7 +23,7 @@ doc = false
 workspace = true
 
 [dependencies]
-reflectapi = { path = "../reflectapi", version = "0.17.2", features = ["codegen"] }
+reflectapi = { path = "../reflectapi", version = "0.17.3-alpha.1", features = ["codegen"] }
 rouille = "3"
 
 clap = { version = "4.5.3", features = ["derive"] }

--- a/reflectapi-demo/clients/python/uv.lock
+++ b/reflectapi-demo/clients/python/uv.lock
@@ -266,7 +266,7 @@ dev = [
 
 [[package]]
 name = "reflectapi-runtime"
-version = "0.17.2"
+version = "0.17.3a1"
 source = { editable = "../../../reflectapi-python-runtime" }
 dependencies = [
     { name = "httpx" },

--- a/reflectapi-derive/Cargo.toml
+++ b/reflectapi-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi-derive"
-version = "0.17.2"
+version = "0.17.3-alpha.1"
 edition = "2021"
 
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ workspace = true
 proc-macro = true
 
 [dependencies]
-reflectapi-schema = { path = '../reflectapi-schema', version = "0.17.2" }
+reflectapi-schema = { path = '../reflectapi-schema', version = "0.17.3-alpha.1" }
 
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/reflectapi-python-runtime/pyproject.toml
+++ b/reflectapi-python-runtime/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "reflectapi-runtime"
-version = "0.17.2"
+version = "0.17.3a1"
 description = "Runtime library for ReflectAPI Python clients"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/reflectapi-python-runtime/src/reflectapi_runtime/__init__.py
+++ b/reflectapi-python-runtime/src/reflectapi_runtime/__init__.py
@@ -50,7 +50,7 @@ from .testing import (
 )
 from .types import BatchResult, ReflectapiEmpty, ReflectapiInfallible
 
-__version__ = "0.17.2"
+__version__ = "0.17.3a1"
 
 __all__ = [
     # Authentication

--- a/reflectapi-schema/Cargo.toml
+++ b/reflectapi-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi-schema"
-version = "0.17.2"
+version = "0.17.3-alpha.1"
 edition = "2021"
 
 license = "Apache-2.0"

--- a/reflectapi/Cargo.toml
+++ b/reflectapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi"
-version = "0.17.2"
+version = "0.17.3-alpha.1"
 edition = "2021"
 
 license = "Apache-2.0"
@@ -20,8 +20,8 @@ workspace = true
 
 [dependencies]
 # workspace dependencies
-reflectapi-derive = { path = "../reflectapi-derive", version = "0.17.2" }
-reflectapi-schema = { path = "../reflectapi-schema", version = "0.17.2" }
+reflectapi-derive = { path = "../reflectapi-derive", version = "0.17.3-alpha.1" }
+reflectapi-schema = { path = "../reflectapi-schema", version = "0.17.3-alpha.1" }
 
 # mandatory 3rd party dependencies
 serde = { version = "1.0.197", features = ["derive"] }


### PR DESCRIPTION
First alpha after dropping `ReflectapiOption` and the Python codegen hardening pass (#151).

Bumps all Cargo packages `0.17.2` → `0.17.3-alpha.1` and the Python runtime `0.17.2` → `0.17.3a1`. Refreshes `Cargo.lock` and the demo client's `uv.lock`. Promotes the "Unreleased" CHANGELOG section.

Tag `v0.17.3-alpha.1` after merge to trigger the release workflow.