### PR TITLE
chore: 0.17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.17.3
+
+Promotes the 0.17.3-alpha.1 work to stable and adds one OpenAPI codegen fix on top:
+
+- **Root-level `Box<T>` (and other transparent pointer wrappers) now resolve in OpenAPI output.** A function taking or returning `Box<TreeNode>` previously emitted `$ref: #/components/schemas/Box<TreeNode>` — a name nothing in the spec registered. The converter now unwraps transparent pointer primitives (`Box`, `Rc`, `Arc`, `Cow`, ...) at the type-reference level so the ref points at the real component. Primitives that carry their own OpenAPI representation (`chrono::DateTime`, `HashSet<T>`, `usize`, ...) are left untouched.
+- **Doc descriptions are scrubbed of embedded `<details><summary>JSON schema</summary>` blocks.** These are useful as human-readable annotations in Rust source but leaked into `info`, `paths`, and component `description` fields in the generated spec.
+
+See the alpha.1 notes below for the rest of the 0.17.3 changes (Python `ReflectapiPartialModel`, TS SSE flush, etc.).
+
 ## 0.17.3-alpha.1
 
 ### Python — partial fields without a wrapper class

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi"
-version = "0.17.3-alpha.1"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi-cli"
-version = "0.17.3-alpha.1"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi-derive"
-version = "0.17.3-alpha.1"
+version = "0.17.3"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi-schema"
-version = "0.17.3-alpha.1"
+version = "0.17.3"
 dependencies = [
  "glob",
  "serde",

--- a/reflectapi-cli/Cargo.toml
+++ b/reflectapi-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi-cli"
-version = "0.17.3-alpha.1"
+version = "0.17.3"
 edition = "2021"
 default-run = "reflectapi"
 
@@ -23,7 +23,7 @@ doc = false
 workspace = true
 
 [dependencies]
-reflectapi = { path = "../reflectapi", version = "0.17.3-alpha.1", features = ["codegen"] }
+reflectapi = { path = "../reflectapi", version = "0.17.3", features = ["codegen"] }
 rouille = "3"
 
 clap = { version = "4.5.3", features = ["derive"] }

--- a/reflectapi-demo/clients/python/uv.lock
+++ b/reflectapi-demo/clients/python/uv.lock
@@ -266,7 +266,7 @@ dev = [
 
 [[package]]
 name = "reflectapi-runtime"
-version = "0.17.3a1"
+version = "0.17.3"
 source = { editable = "../../../reflectapi-python-runtime" }
 dependencies = [
     { name = "httpx" },

--- a/reflectapi-derive/Cargo.toml
+++ b/reflectapi-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi-derive"
-version = "0.17.3-alpha.1"
+version = "0.17.3"
 edition = "2021"
 
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ workspace = true
 proc-macro = true
 
 [dependencies]
-reflectapi-schema = { path = '../reflectapi-schema', version = "0.17.3-alpha.1" }
+reflectapi-schema = { path = '../reflectapi-schema', version = "0.17.3" }
 
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/reflectapi-python-runtime/pyproject.toml
+++ b/reflectapi-python-runtime/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "reflectapi-runtime"
-version = "0.17.3a1"
+version = "0.17.3"
 description = "Runtime library for ReflectAPI Python clients"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/reflectapi-python-runtime/src/reflectapi_runtime/__init__.py
+++ b/reflectapi-python-runtime/src/reflectapi_runtime/__init__.py
@@ -50,7 +50,7 @@ from .testing import (
 )
 from .types import BatchResult, ReflectapiEmpty, ReflectapiInfallible
 
-__version__ = "0.17.3a1"
+__version__ = "0.17.3"
 
 __all__ = [
     # Authentication

--- a/reflectapi-schema/Cargo.toml
+++ b/reflectapi-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi-schema"
-version = "0.17.3-alpha.1"
+version = "0.17.3"
 edition = "2021"
 
 license = "Apache-2.0"

--- a/reflectapi/Cargo.toml
+++ b/reflectapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi"
-version = "0.17.3-alpha.1"
+version = "0.17.3"
 edition = "2021"
 
 license = "Apache-2.0"
@@ -20,8 +20,8 @@ workspace = true
 
 [dependencies]
 # workspace dependencies
-reflectapi-derive = { path = "../reflectapi-derive", version = "0.17.3-alpha.1" }
-reflectapi-schema = { path = "../reflectapi-schema", version = "0.17.3-alpha.1" }
+reflectapi-derive = { path = "../reflectapi-derive", version = "0.17.3" }
+reflectapi-schema = { path = "../reflectapi-schema", version = "0.17.3" }
 
 # mandatory 3rd party dependencies
 serde = { version = "1.0.197", features = ["derive"] }


### PR DESCRIPTION
Promotes 0.17.3-alpha.1 to stable with one additional OpenAPI codegen fix on top (PR #154).

## Summary
- Bump all crates and the Python runtime to 0.17.3
- Refresh Cargo.lock + uv.lock
- Changelog entry covering the box-unwrapping/description-sanitization fix; alpha.1 notes remain underneath

## Test plan
- [x] cargo build --workspace
- [x] cargo test --workspace (green on prior commits)
- [x] uv sync in reflectapi-python-runtime and reflectapi-demo/clients/python
- [ ] CI green before merge