### PR TITLE
Fix Python docstring escaping and namespace imports

### DIFF
--- a/reflectapi-demo/clients/python/api_client/myapi/__init__.py
+++ b/reflectapi-demo/clients/python/api_client/myapi/__init__.py
@@ -51,7 +51,7 @@ StdNumNonZeroI64 = Annotated[int, "Rust NonZero i64 type"]
 
 class MyapiHealthCheckFail(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
 
@@ -60,12 +60,5 @@ HealthCheckFail = MyapiHealthCheckFail
 
 from . import model
 from . import proto
-
-try:
-    from .._rebuild import rebuild_models as _rebuild_models
-
-    _rebuild_models()
-except ImportError:
-    pass
 
 __all__ = ["HealthCheckFail", "MyapiHealthCheckFail", "model", "proto"]

--- a/reflectapi-demo/clients/python/api_client/myapi/model/__init__.py
+++ b/reflectapi-demo/clients/python/api_client/myapi/model/__init__.py
@@ -53,7 +53,7 @@ class MyapiModelBehaviorAggressiveVariant(BaseModel):
     """Aggressive variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: float = Field(description="aggressiveness level")
@@ -64,7 +64,7 @@ class MyapiModelBehaviorOtherVariant(BaseModel):
     """Other variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     description: str = Field(description="Custom provided description of a behavior")
@@ -125,7 +125,7 @@ class MyapiModelKindDog(BaseModel):
     """A dog"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["dog"] = Field(default="dog", description="Discriminator field")
@@ -136,7 +136,7 @@ class MyapiModelKindCat(BaseModel):
     """A cat"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["cat"] = Field(default="cat", description="Discriminator field")
@@ -147,7 +147,7 @@ class MyapiModelKindBird(BaseModel):
     """Test for unit variants in internally tagged enums"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["bird"] = Field(default="bird", description="Discriminator field")

--- a/reflectapi-demo/clients/python/api_client/myapi/model/input/__init__.py
+++ b/reflectapi-demo/clients/python/api_client/myapi/model/input/__init__.py
@@ -51,7 +51,7 @@ StdNumNonZeroI64 = Annotated[int, "Rust NonZero i64 type"]
 
 class MyapiModelInputPet(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     name: str = Field(description="identity")

--- a/reflectapi-demo/clients/python/api_client/myapi/model/output/__init__.py
+++ b/reflectapi-demo/clients/python/api_client/myapi/model/output/__init__.py
@@ -51,7 +51,7 @@ StdNumNonZeroI64 = Annotated[int, "Rust NonZero i64 type"]
 
 class MyapiModelOutputPet(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     name: str = Field(description="identity")

--- a/reflectapi-demo/clients/python/api_client/myapi/proto/__init__.py
+++ b/reflectapi-demo/clients/python/api_client/myapi/proto/__init__.py
@@ -42,6 +42,11 @@ from reflectapi_runtime import (
 T = TypeVar("T")
 
 
+import sys
+from ... import myapi
+
+myapi.proto = sys.modules[__name__]
+
 # External type definitions
 StdNumNonZeroU32 = Annotated[int, "Rust NonZero u32 type"]
 StdNumNonZeroU64 = Annotated[int, "Rust NonZero u64 type"]
@@ -51,7 +56,7 @@ StdNumNonZeroI64 = Annotated[int, "Rust NonZero i64 type"]
 
 class MyapiProtoHeaders(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     authorization: str = Field(description="Authorization header")
@@ -59,7 +64,7 @@ class MyapiProtoHeaders(BaseModel):
 
 class MyapiProtoInternalError(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     message: str
@@ -67,7 +72,7 @@ class MyapiProtoInternalError(BaseModel):
 
 class MyapiProtoPaginated(BaseModel, Generic[T]):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     items: list[T] = Field(description="slice of a collection")
@@ -76,7 +81,7 @@ class MyapiProtoPaginated(BaseModel, Generic[T]):
 
 class MyapiProtoPetsListRequest(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     limit: int | None = None
@@ -85,7 +90,7 @@ class MyapiProtoPetsListRequest(BaseModel):
 
 class MyapiProtoPetsRemoveRequest(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     name: str = Field(description="identity")
@@ -97,6 +102,7 @@ class MyapiProtoPetsUpdateRequest(ReflectapiPartialModel):
         populate_by_name=True,
         validate_assignment=True,
         protected_namespaces=(),
+        defer_build=True,
     )
 
     name: str = Field(description="identity")
@@ -113,7 +119,7 @@ class MyapiProtoPetsUpdateRequest(ReflectapiPartialModel):
 
 class MyapiProtoValidationA(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     message: str
@@ -123,7 +129,7 @@ class MyapiProtoPetsCreateErrorInvalidIdentityVariant(BaseModel):
     """InvalidIdentity variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     message: str
@@ -179,7 +185,7 @@ class MyapiProtoPetsCreateError(RootModel[MyapiProtoPetsCreateErrorVariants]):
 
 class MyapiProtoPetsListErrorInvalidCursor(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     kind: Literal["InvalidCursor"] = Field(
@@ -189,7 +195,7 @@ class MyapiProtoPetsListErrorInvalidCursor(BaseModel):
 
 class MyapiProtoPetsListErrorUnauthorized(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     kind: Literal["Unauthorized"] = Field(
@@ -199,7 +205,7 @@ class MyapiProtoPetsListErrorUnauthorized(BaseModel):
 
 class MyapiProtoPetsListErrorInternal(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     kind: Literal["Internal"] = Field(
@@ -228,10 +234,10 @@ class MyapiProtoPetsUpdateErrorValidationVariant(BaseModel):
     """Validation variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
-    field_0: list[myapi.proto.ValidationError]
+    field_0: list[ValidationError]
 
 
 # Externally tagged enum using RootModel
@@ -284,10 +290,10 @@ class MyapiProtoValidationErrorValidationAVariant(BaseModel):
     """ValidationA variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
-    field_0: myapi.proto.ValidationA
+    field_0: ValidationA
 
 
 # Externally tagged enum using RootModel

--- a/reflectapi-demo/clients/typescript/generated.ts
+++ b/reflectapi-demo/clients/typescript/generated.ts
@@ -23,8 +23,11 @@ export { ClientInstance };
 export type { Client, RequestOptions };
 
 type IsAny<T> = 0 extends 1 & T ? true : false;
-export type NullToEmptyObject<T> =
-  IsAny<T> extends true ? unknown : T extends null ? {} : T;
+export type NullToEmptyObject<T> = IsAny<T> extends true
+  ? unknown
+  : T extends null
+    ? {}
+    : T;
 
 export type AsyncResult<T, E> = Promise<Result<T, Err<E>>>;
 

--- a/reflectapi-demo/src/tests/namespace.rs
+++ b/reflectapi-demo/src/tests/namespace.rs
@@ -370,6 +370,61 @@ fn test_python_split_modules_defer_peer_namespace_imports() {
 }
 
 #[test]
+fn test_python_split_modules_client_uses_hashed_namespace_class_name() {
+    #[derive(
+        Debug, serde::Serialize, serde::Deserialize, reflectapi::Input, reflectapi::Output,
+    )]
+    struct LongRequest {
+        value: String,
+    }
+
+    async fn long_get<S>(_s: S, request: LongRequest, _: reflectapi::Empty) -> LongRequest {
+        request
+    }
+
+    let long_type_name = "tier1::GenericPredictionRequestVisionAnnotationBulkInputAnnotatedUnionVertexVisionAnnotationConfigStaticVisionAnnotationConfigRealtimeVisionAnnotationConfigBackgroundVisionAnnotationConfigRealtimeSyncVisionAnnotationConfigSymbolTextVisionAnnotationConfigRealtimeSupplierVisionAnnotationConfigLineBoxObbVisionAnnotationConfigPncocrVisionAnnotationConfigPncVisionAnnotationConfigStyleTransferPostProcessVisionAnnotationConfigStyleTransferLineBoxVisionAnnotationConfigFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorStrategy";
+    let long_leaf_name = long_type_name.split("::").last().unwrap();
+
+    let (schema, _) = reflectapi::Builder::<()>::new()
+        .route(long_get, |b| b.name("tier1.long.get"))
+        .rename_types(
+            "reflectapi_demo::tests::namespace::LongRequest",
+            long_type_name,
+        )
+        .build()
+        .unwrap();
+
+    let files = reflectapi::codegen::python::generate_files(
+        schema,
+        &reflectapi::codegen::python::Config::default(),
+    )
+    .unwrap();
+
+    let tier1_file = files.get("tier1/__init__.py").unwrap();
+    let class_line = tier1_file
+        .lines()
+        .find(|line| {
+            line.starts_with("class Tier1GenericPredictionRequestVisionAnnotationBulkInput")
+        })
+        .unwrap();
+    let class_name = class_line
+        .strip_prefix("class ")
+        .unwrap()
+        .split('(')
+        .next()
+        .unwrap();
+    let alias_name = class_name.strip_prefix("Tier1").unwrap();
+
+    assert!(class_name.len() <= 80);
+    assert_ne!(class_name, format!("Tier1{long_leaf_name}"));
+    assert!(tier1_file.contains(&format!("{alias_name} = (\n    {class_name}\n)")));
+
+    let client_file = files.get("_client.py").unwrap();
+    assert!(client_file.contains(&format!("tier1.{alias_name}")));
+    assert!(!client_file.contains(&format!("tier1.{long_leaf_name}")));
+}
+
+#[test]
 fn test_python_split_modules_placeholder_deferred_builtin_namespaces() {
     #[derive(
         Debug, serde::Serialize, serde::Deserialize, reflectapi::Input, reflectapi::Output,

--- a/reflectapi-demo/src/tests/namespace.rs
+++ b/reflectapi-demo/src/tests/namespace.rs
@@ -158,6 +158,270 @@ fn test_python_init_exports_client() {
 }
 
 #[test]
+fn test_python_split_modules_bind_referenced_namespaces() {
+    #[derive(
+        Debug, serde::Serialize, serde::Deserialize, reflectapi::Input, reflectapi::Output,
+    )]
+    enum Status {
+        Pending,
+    }
+
+    #[derive(
+        Debug, serde::Serialize, serde::Deserialize, reflectapi::Input, reflectapi::Output,
+    )]
+    struct Item {
+        value: String,
+    }
+
+    #[derive(
+        Debug, serde::Serialize, serde::Deserialize, reflectapi::Input, reflectapi::Output,
+    )]
+    struct OutputChild {
+        value: String,
+    }
+
+    #[derive(
+        Debug, serde::Serialize, serde::Deserialize, reflectapi::Input, reflectapi::Output,
+    )]
+    struct OutputSummary {
+        child: OutputChild,
+    }
+
+    #[derive(
+        Debug, serde::Serialize, serde::Deserialize, reflectapi::Input, reflectapi::Output,
+    )]
+    struct Order {
+        status: Status,
+        items: Vec<Item>,
+        summary: OutputSummary,
+    }
+
+    #[derive(
+        Debug, serde::Serialize, serde::Deserialize, reflectapi::Input, reflectapi::Output,
+    )]
+    struct RootWrapper {
+        order: Order,
+    }
+
+    async fn order_get<S>(_s: S, _: reflectapi::Empty, _: reflectapi::Empty) -> Order {
+        Order {
+            status: Status::Pending,
+            items: vec![],
+            summary: OutputSummary {
+                child: OutputChild {
+                    value: String::new(),
+                },
+            },
+        }
+    }
+
+    async fn wrapper_get<S>(_s: S, _: reflectapi::Empty, _: reflectapi::Empty) -> RootWrapper {
+        RootWrapper {
+            order: Order {
+                status: Status::Pending,
+                items: vec![],
+                summary: OutputSummary {
+                    child: OutputChild {
+                        value: String::new(),
+                    },
+                },
+            },
+        }
+    }
+
+    let (schema, _) = reflectapi::Builder::<()>::new()
+        .route(order_get, |b| b.name("order.get"))
+        .route(wrapper_get, |b| b.name("wrapper.get"))
+        .rename_types(
+            "reflectapi_demo::tests::namespace::Status",
+            "lookup::Status",
+        )
+        .rename_types("reflectapi_demo::tests::namespace::Item", "order::Item")
+        .rename_types("reflectapi_demo::tests::namespace::Order", "order::Order")
+        .rename_types(
+            "reflectapi_demo::tests::namespace::RootWrapper",
+            "RootWrapper",
+        )
+        .rename_types(
+            "reflectapi_demo::tests::namespace::OutputChild",
+            "order::output::Child",
+        )
+        .rename_types(
+            "reflectapi_demo::tests::namespace::OutputSummary",
+            "order::output::Summary",
+        )
+        .build()
+        .unwrap();
+
+    let files = reflectapi::codegen::python::generate_files(
+        schema,
+        &reflectapi::codegen::python::Config::default(),
+    )
+    .unwrap();
+    let order_file = files.get("order/__init__.py").unwrap();
+
+    assert!(order_file.contains("import sys"));
+    assert!(order_file.contains("from .. import lookup"));
+    assert!(order_file.contains("order = sys.modules[__name__]"));
+    assert!(order_file.contains("from . import output"));
+    assert!(order_file.contains("status: lookup.Status"));
+    assert!(order_file.contains("items: list[Item]"));
+    assert!(order_file.contains("summary: output.Summary"));
+    assert!(order_file.contains("defer_build=True"));
+    assert!(!order_file.contains("_rebuild_models()"));
+
+    let output_file = files.get("order/output/__init__.py").unwrap();
+    assert!(output_file.contains("import sys"));
+    assert!(output_file.contains("from ... import order"));
+    assert!(output_file.contains("order.output = sys.modules[__name__]"));
+    assert!(output_file.contains("child: Child"));
+    assert!(output_file.contains("defer_build=True"));
+
+    let root_types_file = files.get("_types.py").unwrap();
+    assert!(root_types_file.contains("from typing import TYPE_CHECKING"));
+    assert!(root_types_file.contains("if TYPE_CHECKING:"));
+    assert!(root_types_file.contains("from . import order"));
+    assert!(root_types_file.contains("order: order.Order"));
+}
+
+#[test]
+fn test_python_split_modules_defer_peer_namespace_imports() {
+    #[derive(
+        Debug, serde::Serialize, serde::Deserialize, reflectapi::Input, reflectapi::Output,
+    )]
+    enum Metric {
+        Price,
+    }
+
+    #[derive(
+        Debug, serde::Serialize, serde::Deserialize, reflectapi::Input, reflectapi::Output,
+    )]
+    struct Sort<T> {
+        value: T,
+    }
+
+    #[derive(
+        Debug, serde::Serialize, serde::Deserialize, reflectapi::Input, reflectapi::Output,
+    )]
+    struct Criterion {
+        sort: Sort<Metric>,
+    }
+
+    #[derive(
+        Debug, serde::Serialize, serde::Deserialize, reflectapi::Input, reflectapi::Output,
+    )]
+    struct Basket {
+        criterion: Criterion,
+    }
+
+    async fn basket_get<S>(_s: S, _: reflectapi::Empty, _: reflectapi::Empty) -> Basket {
+        Basket {
+            criterion: Criterion {
+                sort: Sort {
+                    value: Metric::Price,
+                },
+            },
+        }
+    }
+
+    let (schema, _) = reflectapi::Builder::<()>::new()
+        .route(basket_get, |b| b.name("basket.get"))
+        .rename_types(
+            "reflectapi_demo::tests::namespace::Basket",
+            "basket_builder::Basket",
+        )
+        .rename_types(
+            "reflectapi_demo::tests::namespace::Sort",
+            "basket_builder::Sort",
+        )
+        .rename_types(
+            "reflectapi_demo::tests::namespace::Criterion",
+            "basket_builder_basket::Criterion",
+        )
+        .rename_types(
+            "reflectapi_demo::tests::namespace::Metric",
+            "basket_builder_basket::Metric",
+        )
+        .build()
+        .unwrap();
+
+    let files = reflectapi::codegen::python::generate_files(
+        schema,
+        &reflectapi::codegen::python::Config::default(),
+    )
+    .unwrap();
+    let basket_builder_file = files.get("basket_builder/__init__.py").unwrap();
+    let basket_builder_import = basket_builder_file
+        .find("from .. import basket_builder_basket")
+        .unwrap();
+    let sort_alias = basket_builder_file
+        .find("Sort = BasketBuilderSort")
+        .unwrap();
+    assert!(basket_builder_import > sort_alias);
+    assert!(basket_builder_file.contains("criterion: basket_builder_basket.Criterion"));
+
+    let basket_file = files.get("basket_builder_basket/__init__.py").unwrap();
+    let parent_import = basket_file.find("from .. import basket_builder").unwrap();
+    let metric_alias = basket_file
+        .find("Metric = BasketBuilderBasketMetric")
+        .unwrap();
+    assert!(parent_import > metric_alias);
+    assert!(basket_file.contains("sort: basket_builder.Sort[Metric]"));
+}
+
+#[test]
+fn test_python_split_modules_placeholder_deferred_builtin_namespaces() {
+    #[derive(
+        Debug, serde::Serialize, serde::Deserialize, reflectapi::Input, reflectapi::Output,
+    )]
+    struct PricingModel {
+        value: u8,
+    }
+
+    #[derive(
+        Debug, serde::Serialize, serde::Deserialize, reflectapi::Input, reflectapi::Output,
+    )]
+    struct BillingRequest {
+        pricing_model: PricingModel,
+    }
+
+    async fn billing_get<S>(_s: S, _: reflectapi::Empty, _: reflectapi::Empty) -> BillingRequest {
+        BillingRequest {
+            pricing_model: PricingModel { value: 1 },
+        }
+    }
+
+    let (schema, _) = reflectapi::Builder::<()>::new()
+        .route(billing_get, |b| b.name("billing.get"))
+        .rename_types(
+            "reflectapi_demo::tests::namespace::BillingRequest",
+            "billing::Request",
+        )
+        .rename_types(
+            "reflectapi_demo::tests::namespace::PricingModel",
+            "billing::input::PricingModel",
+        )
+        .build()
+        .unwrap();
+
+    let files = reflectapi::codegen::python::generate_files(
+        schema,
+        &reflectapi::codegen::python::Config::default(),
+    )
+    .unwrap();
+    let billing_file = files.get("billing/__init__.py").unwrap();
+    let placeholder = billing_file
+        .find("input = _ReflectapiDeferredNamespace()")
+        .unwrap();
+    let request_class = billing_file.find("class BillingRequest").unwrap();
+    let child_import = billing_file.find("from . import input").unwrap();
+
+    assert!(placeholder < request_class);
+    assert!(child_import > request_class);
+    assert!(billing_file.contains("pricing_model: input.PricingModel"));
+}
+
+#[test]
 fn test_python_module_path_collision_errors() {
     #[derive(
         Debug, serde::Serialize, serde::Deserialize, reflectapi::Input, reflectapi::Output,

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_deprecated-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_deprecated-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicStructWithDeprecatedField(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_enum_documented-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_enum_documented-4.snap
@@ -46,7 +46,7 @@ class ReflectapiDemoTestsBasicTestEnumDocumentedVariant1Variant(BaseModel, Gener
     """Variant1 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: T = Field(description="variant1 field docs")
@@ -56,7 +56,7 @@ class ReflectapiDemoTestsBasicTestEnumDocumentedVariant2Variant(BaseModel, Gener
     """Variant2 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     named_field: T = Field(description="named field variant2 field docs")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_documented-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_documented-4.snap
@@ -30,7 +30,7 @@ class ReflectapiDemoTestsBasicTestStructDocumented(BaseModel):
     more"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(description="field docs\nmultiline")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_empty-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_empty-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructEmpty(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_static_str-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_static_str-4.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructOneBasicFieldStaticStr(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: str = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string-4.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructOneBasicFieldString(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: str = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructOneBasicFieldStringReflectBoth(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: str = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally-5.snap
@@ -28,7 +28,7 @@ class ReflectapiDemoTestsBasicTestStructOneBasicFieldStringReflectBothEqually(
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally2-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_equally2-4.snap
@@ -28,7 +28,7 @@ class ReflectapiDemoTestsBasicTestStructOneBasicFieldStringReflectBothEqually(
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_with_attributes-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_string_reflectapi_both_with_attributes-5.snap
@@ -28,7 +28,7 @@ class ReflectapiDemoTestsBasicInputTestStructOneBasicFieldStringReflectBothDiffe
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(serialization_alias="_f", validation_alias="_f")
@@ -38,7 +38,7 @@ class ReflectapiDemoTestsBasicOutputTestStructOneBasicFieldStringReflectBothD_af
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(serialization_alias="_f", validation_alias="_f")
@@ -77,7 +77,7 @@ class AsyncInoutClient:
             reflectapi_demo.tests.basic.input.TestStructOneBasicFieldStringReflectBothDifferently
         ] = None,
     ) -> ApiResponse[
-        reflectapi_demo.tests.basic.output.TestStructOneBasicFieldStringReflectBothDifferently
+        reflectapi_demo.tests.basic.output.TestStructOneBasicFieldStringReflectBothD_afce1cc8
     ]:
         """
 
@@ -85,7 +85,7 @@ class AsyncInoutClient:
             data: Request data for the test operation.
 
         Returns:
-            ApiResponse[reflectapi_demo.tests.basic.output.TestStructOneBasicFieldStringReflectBothDifferently]: Response containing reflectapi_demo.tests.basic.output.TestStructOneBasicFieldStringReflectBothDifferently data
+            ApiResponse[reflectapi_demo.tests.basic.output.TestStructOneBasicFieldStringReflectBothD_afce1cc8]: Response containing reflectapi_demo.tests.basic.output.TestStructOneBasicFieldStringReflectBothD_afce1cc8 data
         """
         path = "/inout_test"
 
@@ -94,7 +94,7 @@ class AsyncInoutClient:
             path,
             params=params if params else None,
             json_model=data,
-            response_model=reflectapi_demo.tests.basic.output.TestStructOneBasicFieldStringReflectBothDifferently,
+            response_model=reflectapi_demo.tests.basic.output.TestStructOneBasicFieldStringReflectBothD_afce1cc8,
         )
 
 
@@ -123,7 +123,7 @@ class InoutClient:
             reflectapi_demo.tests.basic.input.TestStructOneBasicFieldStringReflectBothDifferently
         ] = None,
     ) -> ApiResponse[
-        reflectapi_demo.tests.basic.output.TestStructOneBasicFieldStringReflectBothDifferently
+        reflectapi_demo.tests.basic.output.TestStructOneBasicFieldStringReflectBothD_afce1cc8
     ]:
         """
 
@@ -131,7 +131,7 @@ class InoutClient:
             data: Request data for the test operation.
 
         Returns:
-            ApiResponse[reflectapi_demo.tests.basic.output.TestStructOneBasicFieldStringReflectBothDifferently]: Response containing reflectapi_demo.tests.basic.output.TestStructOneBasicFieldStringReflectBothDifferently data
+            ApiResponse[reflectapi_demo.tests.basic.output.TestStructOneBasicFieldStringReflectBothD_afce1cc8]: Response containing reflectapi_demo.tests.basic.output.TestStructOneBasicFieldStringReflectBothD_afce1cc8 data
         """
         path = "/inout_test"
 
@@ -140,7 +140,7 @@ class InoutClient:
             path,
             params=params if params else None,
             json_model=data,
-            response_model=reflectapi_demo.tests.basic.output.TestStructOneBasicFieldStringReflectBothDifferently,
+            response_model=reflectapi_demo.tests.basic.output.TestStructOneBasicFieldStringReflectBothD_afce1cc8,
         )
 
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_u32-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_one_basic_field_u32-4.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructOneBasicFieldU32(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_option-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_option-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructOption(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int | None = Field(default=None, serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_tuple-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_tuple-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructTuple(BaseModel):
 
-    model_config = ConfigDict(extra="ignore", populate_by_name=True, protected_namespaces=())
+    model_config = ConfigDict(extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True)
 
     0: int
     1: str

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_additional_derives-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_additional_derives-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTest(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     us: list[None]
@@ -37,7 +37,7 @@ class ReflectapiDemoTestsBasicTest(BaseModel):
 
 class ReflectapiDemoTestsBasicX(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_all_primitive_type_fields-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_all_primitive_type_fields-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithAllPrimitiveTypeFields(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f_u8: int = Field(serialization_alias="_f_u8", validation_alias="_f_u8")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithArc(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc_pointer_only-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_arc_pointer_only-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithArcPointerOnly(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f_pointer_arc: int = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_input_only-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_input_only-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithAttributesInputOnly(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: str = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_output_only-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_attributes_output_only-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithAttributesOutputOnly(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: str = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_external_generic_type_fallback-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_external_generic_type_fallback-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithExternalGenericTypeFallback(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     data: dict[str, int]

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_fixed_size_array-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_fixed_size_array-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithFixedSizeArray(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: list[int] = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashmap-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashmap-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithHashMap(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: dict[int, str] = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithHashSetField(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f_hashset: list[int] = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field_generic-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_hashset_field_generic-5.snap
@@ -32,7 +32,7 @@ G = TypeVar("G")
 
 class ReflectapiDemoTestsBasicTestStructWithHashSetFieldGeneric(BaseModel, Generic[G]):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f_hashset: list[G] = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructNested(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: str = Field(serialization_alias="_f", validation_alias="_f")
@@ -34,7 +34,7 @@ class ReflectapiDemoTestsBasicTestStructNested(BaseModel):
 
 class ReflectapiDemoTestsBasicTestStructWithNested(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: reflectapi_demo.tests.basic.TestStructNested = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested_external-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_nested_external-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithNestedExternal(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: reflectapi_demo.tests.test_lib.TestStructNested = Field(
@@ -36,7 +36,7 @@ class ReflectapiDemoTestsBasicTestStructWithNestedExternal(BaseModel):
 
 class ReflectapiDemoTestsTestLibTestStructNested(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: str = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_self_via_arc-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_self_via_arc-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithSelfViaArc(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: reflectapi_demo.tests.basic.TestStructWithSelfViaArc = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithSkipField(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_input-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_input-5.snap
@@ -26,13 +26,13 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicInputTestStructWithSkipFieldInput(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
 
 class ReflectapiDemoTestsBasicOutputTestStructWithSkipFieldInput(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_output-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_skip_field_output-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicInputTestStructWithSkipFieldOutput(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(serialization_alias="_f", validation_alias="_f")
@@ -34,7 +34,7 @@ class ReflectapiDemoTestsBasicInputTestStructWithSkipFieldOutput(BaseModel):
 
 class ReflectapiDemoTestsBasicOutputTestStructWithSkipFieldOutput(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_array-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_array-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithTransformArray(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: list[int] = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_both-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_both-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithTransformBoth(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithTransformFallback(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback_nested-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_fallback_nested-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithTransformFallbackNested(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_input-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_input-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicInputTestStructWithTransformInput(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(serialization_alias="_f", validation_alias="_f")
@@ -34,7 +34,7 @@ class ReflectapiDemoTestsBasicInputTestStructWithTransformInput(BaseModel):
 
 class ReflectapiDemoTestsBasicOutputTestStructWithTransformInput(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_output-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_transform_output-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicInputTestStructWithTransformOutput(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(serialization_alias="_f", validation_alias="_f")
@@ -34,7 +34,7 @@ class ReflectapiDemoTestsBasicInputTestStructWithTransformOutput(BaseModel):
 
 class ReflectapiDemoTestsBasicOutputTestStructWithTransformOutput(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithTuple(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: tuple[int, str] = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple12-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_tuple12-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithTuple12(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: tuple[int, str, int, str, int, str, int, str, int, str, int, str] = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithVec(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: list[int] = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_external-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_external-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithVecExternal(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: list[reflectapi_demo.tests.test_lib.TestStructNested] = Field(
@@ -36,7 +36,7 @@ class ReflectapiDemoTestsBasicTestStructWithVecExternal(BaseModel):
 
 class ReflectapiDemoTestsTestLibTestStructNested(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: str = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_nested-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_nested-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithVecNested(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: list[list[reflectapi_demo.tests.test_lib.TestStructNested]] = Field(
@@ -36,7 +36,7 @@ class ReflectapiDemoTestsBasicTestStructWithVecNested(BaseModel):
 
 class ReflectapiDemoTestsTestLibTestStructNested(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: str = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_two-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__basic__reflectapi_struct_with_vec_two-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsBasicTestStructWithVecTwo(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: list[int] = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_basic_variant_and_fields_and_named_fields-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_basic_variant_and_fields_and_named_fields-4.snap
@@ -42,7 +42,7 @@ class ReflectapiDemoTestsEnumsTestEnumWithBasicVariantAndFieldsAndNamedFieldsVar
     """Variant1 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: int
@@ -55,7 +55,7 @@ class ReflectapiDemoTestsEnumsTestEnumWithBasicVariantAndFieldsAndNamedFieldsVar
     """Variant2 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field1: int

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_empty_variant_and_fields-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_empty_variant_and_fields-4.snap
@@ -42,7 +42,7 @@ class ReflectapiDemoTestsEnumsTestEnumWithEmptyVariantAndFieldsVariant2Variant(
     """Variant2 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: int

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_fields-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_fields-4.snap
@@ -40,7 +40,7 @@ class ReflectapiDemoTestsEnumsTestEnumWithFieldsVariant1Variant(BaseModel):
     """Variant1 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: int
@@ -50,7 +50,7 @@ class ReflectapiDemoTestsEnumsTestEnumWithFieldsVariant2Variant(BaseModel):
     """Variant2 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: str

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics-4.snap
@@ -48,7 +48,7 @@ class ReflectapiDemoTestsEnumsTestEnumWithGenericsVariant1Variant(
     """Variant1 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: T
@@ -60,7 +60,7 @@ class ReflectapiDemoTestsEnumsTestEnumWithGenericsVariant2Variant(
     """Variant2 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: T

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields-4.snap
@@ -48,7 +48,7 @@ class ReflectapiDemoTestsEnumsTestEnumWithGenericsAndFieldsVariant1Variant(
     """Variant1 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: int
@@ -60,7 +60,7 @@ class ReflectapiDemoTestsEnumsTestEnumWithGenericsAndFieldsVariant2Variant(
     """Variant2 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: T

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields_and_named_fields-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__enum_with_generics_and_fields_and_named_fields-4.snap
@@ -48,7 +48,7 @@ class ReflectapiDemoTestsEnumsTestEnumWithGenericsAndFieldsAndNamedFieldsVariant
     """Variant1 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: int
@@ -60,7 +60,7 @@ class ReflectapiDemoTestsEnumsTestEnumWithGenericsAndFieldsAndNamedFieldsVariant
     """Variant2 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: T
@@ -73,7 +73,7 @@ class ReflectapiDemoTestsEnumsTestEnumWithGenericsAndFieldsAndNamedFieldsVariant
     """Variant3 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field1: int

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__internally_tagged_enum_with_tuple_variants-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__internally_tagged_enum_with_tuple_variants-5.snap
@@ -32,7 +32,7 @@ class ReflectapiDemoTestsEnumsA(str, Enum):
 
 class ReflectapiDemoTestsEnumsEA(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["a"] = Field(default="a", description="Discriminator field")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__internally_tagged_enum_with_unit_variants-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__enums__internally_tagged_enum_with_unit_variants-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsEnumsAX(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["X"] = Field(default="X", description="Discriminator field")
@@ -35,7 +35,7 @@ class ReflectapiDemoTestsEnumsAX(BaseModel):
 
 class ReflectapiDemoTestsEnumsAY(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Y"] = Field(default="Y", description="Discriminator field")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference-4.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsGenericsTestStructWithCircularReference(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: reflectapi_demo.tests.generics.TestStructWithCircularReference = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic-4.snap
@@ -34,7 +34,7 @@ class ReflectapiDemoTestsGenericsTestStructWithCircularReferenceGeneric(
     BaseModel, Generic[T]
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: reflectapi_demo.tests.generics.TestStructWithCircularReferenceGeneric[T] = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_parent-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_parent-4.snap
@@ -34,7 +34,7 @@ class ReflectapiDemoTestsGenericsTestStructWithCircularReferenceGeneric(
     BaseModel, Generic[T]
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: reflectapi_demo.tests.generics.TestStructWithCircularReferenceGeneric[T] = Field(
@@ -47,7 +47,7 @@ class ReflectapiDemoTestsGenericsTestStructWithCircularReferenceGenericParent(
     BaseModel, Generic[T]
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: reflectapi_demo.tests.generics.TestStructWithCircularReferenceGeneric[

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box-4.snap
@@ -36,7 +36,7 @@ class ReflectapiDemoTestsGenericsTestStructWithCircularReferenceGenericWithoutBo
     BaseModel, Generic[A, B]
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f1: A = Field(serialization_alias="_f1", validation_alias="_f1")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent-4.snap
@@ -40,7 +40,7 @@ class ReflectapiDemoTestsGenericsTestStructWithCircularReferenceGenericWithoutBo
     BaseModel, Generic[A, B]
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f1: A = Field(serialization_alias="_f1", validation_alias="_f1")
@@ -51,7 +51,7 @@ class ReflectapiDemoTestsGenericsTestStructWithCircularReferenceGenericWithou_8e
     BaseModel, Generic[C, D]
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: reflectapi_demo.tests.generics.TestStructWithCircularReferenceGenericWithoutBox[
@@ -82,11 +82,11 @@ class AsyncInputClient:
     async def test(
         self,
         data: Optional[
-            reflectapi_demo.tests.generics.TestStructWithCircularReferenceGenericWithoutBoxParent[
-                reflectapi_demo.tests.generics.TestStructWithCircularReferenceGenericWithoutBoxParent[
+            reflectapi_demo.tests.generics.TestStructWithCircularReferenceGenericWithou_8e2b5cb9[
+                reflectapi_demo.tests.generics.TestStructWithCircularReferenceGenericWithou_8e2b5cb9[
                     int, int
                 ],
-                reflectapi_demo.tests.generics.TestStructWithCircularReferenceGenericWithoutBoxParent[
+                reflectapi_demo.tests.generics.TestStructWithCircularReferenceGenericWithou_8e2b5cb9[
                     str, int
                 ],
             ]
@@ -133,11 +133,11 @@ class InputClient:
     def test(
         self,
         data: Optional[
-            reflectapi_demo.tests.generics.TestStructWithCircularReferenceGenericWithoutBoxParent[
-                reflectapi_demo.tests.generics.TestStructWithCircularReferenceGenericWithoutBoxParent[
+            reflectapi_demo.tests.generics.TestStructWithCircularReferenceGenericWithou_8e2b5cb9[
+                reflectapi_demo.tests.generics.TestStructWithCircularReferenceGenericWithou_8e2b5cb9[
                     int, int
                 ],
-                reflectapi_demo.tests.generics.TestStructWithCircularReferenceGenericWithoutBoxParent[
+                reflectapi_demo.tests.generics.TestStructWithCircularReferenceGenericWithou_8e2b5cb9[
                     str, int
                 ],
             ]

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent_specific-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_circular_reference_generic_without_box_parent_specific-4.snap
@@ -36,7 +36,7 @@ class ReflectapiDemoTestsGenericsTestStructWithCircularReferenceGenericWithoutBo
     BaseModel, Generic[A, B]
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f1: A = Field(serialization_alias="_f1", validation_alias="_f1")
@@ -47,7 +47,7 @@ class ReflectapiDemoTestsGenericsTestStructWithCircularReferenceGenericWithou_be
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: reflectapi_demo.tests.generics.TestStructWithCircularReferenceGenericWithoutBox[
@@ -83,7 +83,7 @@ class AsyncInputClient:
     async def test(
         self,
         data: Optional[
-            reflectapi_demo.tests.generics.TestStructWithCircularReferenceGenericWithoutBoxParentSpecific
+            reflectapi_demo.tests.generics.TestStructWithCircularReferenceGenericWithou_be812837
         ] = None,
     ) -> ApiResponse[Any]:
         """
@@ -127,7 +127,7 @@ class InputClient:
     def test(
         self,
         data: Optional[
-            reflectapi_demo.tests.generics.TestStructWithCircularReferenceGenericWithoutBoxParentSpecific
+            reflectapi_demo.tests.generics.TestStructWithCircularReferenceGenericWithou_be812837
         ] = None,
     ) -> ApiResponse[Any]:
         """

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct-4.snap
@@ -32,7 +32,7 @@ A = TypeVar("A")
 
 class ReflectapiDemoTestsGenericsTestStructWithNestedGenericStruct(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: reflectapi_demo.tests.generics.TestStructWithSimpleGeneric[
@@ -42,7 +42,7 @@ class ReflectapiDemoTestsGenericsTestStructWithNestedGenericStruct(BaseModel):
 
 class ReflectapiDemoTestsGenericsTestStructWithSimpleGeneric(BaseModel, Generic[A]):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: A = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct_twice-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_nested_generic_struct_twice-4.snap
@@ -32,7 +32,7 @@ A = TypeVar("A")
 
 class ReflectapiDemoTestsGenericsTestStructWithNestedGenericStructTwice(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: reflectapi_demo.tests.generics.TestStructWithSimpleGeneric[int] = Field(
@@ -45,7 +45,7 @@ class ReflectapiDemoTestsGenericsTestStructWithNestedGenericStructTwice(BaseMode
 
 class ReflectapiDemoTestsGenericsTestStructWithSimpleGeneric(BaseModel, Generic[A]):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: A = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_simple_generic-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_simple_generic-4.snap
@@ -32,7 +32,7 @@ A = TypeVar("A")
 
 class ReflectapiDemoTestsGenericsTestStructWithSimpleGeneric(BaseModel, Generic[A]):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: A = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic-4.snap
@@ -32,7 +32,7 @@ T = TypeVar("T")
 
 class ReflectapiDemoTestsGenericsTestStructWithVecGeneric(BaseModel, Generic[T]):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: list[T] = Field(serialization_alias="_f", validation_alias="_f")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic-4.snap
@@ -34,7 +34,7 @@ T = TypeVar("T")
 
 class ReflectapiDemoTestsGenericsTestStructWithSimpleGeneric(BaseModel, Generic[A]):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: A = Field(serialization_alias="_f", validation_alias="_f")
@@ -42,7 +42,7 @@ class ReflectapiDemoTestsGenericsTestStructWithSimpleGeneric(BaseModel, Generic[
 
 class ReflectapiDemoTestsGenericsTestStructWithVecGenericGeneric(BaseModel, Generic[T]):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: list[reflectapi_demo.tests.generics.TestStructWithSimpleGeneric[T]] = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic_generic-4.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__generics__struct_with_vec_generic_generic_generic-4.snap
@@ -32,7 +32,7 @@ T = TypeVar("T")
 
 class ReflectapiDemoTestsGenericsTestStructWithVecGeneric(BaseModel, Generic[T]):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: list[T] = Field(serialization_alias="_f", validation_alias="_f")
@@ -42,7 +42,7 @@ class ReflectapiDemoTestsGenericsTestStructWithVecGenericGenericGeneric(
     BaseModel, Generic[T]
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: list[reflectapi_demo.tests.generics.TestStructWithVecGeneric[T]] = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__adj_repr_enum_with_untagged_variant-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__adj_repr_enum_with_untagged_variant-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestVariant1(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Variant1"] = Field(
@@ -38,7 +38,7 @@ class ReflectapiDemoTestsSerdeTestVariant1(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestVariant2(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Variant2"] = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__box_field_unwrapping-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__box_field_unwrapping-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTreeNode(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     label: str

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__datetime-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__datetime-5.snap
@@ -28,7 +28,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestStruct(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     duration: ReflectapiDuration

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_adjacently_tagged-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_adjacently_tagged-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestEmptyVariantsAdjacentlyTaggedEmpty(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     t: Literal["Empty"] = Field(default="Empty", description="Discriminator field")
@@ -35,7 +35,7 @@ class ReflectapiDemoTestsSerdeTestEmptyVariantsAdjacentlyTaggedEmpty(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestEmptyVariantsAdjacentlyTaggedEmptyUnit(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     t: Literal["EmptyUnit"] = Field(
@@ -50,13 +50,13 @@ class ReflectapiDemoTestsSerdeTestEmptyVariantsAdjacentlyTaggedEmptyStructConten
     """EmptyStruct content"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
 
 class ReflectapiDemoTestsSerdeTestEmptyVariantsAdjacentlyTaggedEmptyStruct(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     t: Literal["EmptyStruct"] = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_externally_tagged-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_externally_tagged-5.snap
@@ -42,7 +42,7 @@ class ReflectapiDemoTestsSerdeTestEmptyVariantsExternallyTaggedEmptyUnitVariant(
     """EmptyUnit variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
 
@@ -52,7 +52,7 @@ class ReflectapiDemoTestsSerdeTestEmptyVariantsExternallyTaggedEmptyStructVarian
     """EmptyStruct variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_internally_tagged-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_internally_tagged-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestEmptyVariantsInterallyTaggedEmpty(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Empty"] = Field(default="Empty", description="Discriminator field")
@@ -35,7 +35,7 @@ class ReflectapiDemoTestsSerdeTestEmptyVariantsInterallyTaggedEmpty(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestEmptyVariantsInterallyTaggedEmptyStruct(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["EmptyStruct"] = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_untagged-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__empty_variants_untagged-5.snap
@@ -27,19 +27,19 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestEmptyVariantsUntaggedEmpty(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
 
 class ReflectapiDemoTestsSerdeTestEmptyVariantsUntaggedEmptyUnit(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
 
 class ReflectapiDemoTestsSerdeTestEmptyVariantsUntaggedEmptyStruct(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_mixed_variant_types_internally_tagged-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_mixed_variant_types_internally_tagged-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeMixedUnit(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Unit"] = Field(default="Unit", description="Discriminator field")
@@ -35,7 +35,7 @@ class ReflectapiDemoTestsSerdeMixedUnit(BaseModel):
 
 class ReflectapiDemoTestsSerdeMixedWrap(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Wrap"] = Field(default="Wrap", description="Discriminator field")
@@ -44,7 +44,7 @@ class ReflectapiDemoTestsSerdeMixedWrap(BaseModel):
 
 class ReflectapiDemoTestsSerdeMixedFull(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Full"] = Field(default="Full", description="Discriminator field")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all_on_variant-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_all_on_variant-5.snap
@@ -40,7 +40,7 @@ class ReflectapiDemoTestsSerdeTestEnumRenameAllOnVariantVariant1Variant(BaseMode
     """Variant1 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_name: int = Field(
@@ -52,7 +52,7 @@ class ReflectapiDemoTestsSerdeTestEnumRenameAllOnVariantVariant2Variant(BaseMode
     """Variant2 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: int

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_variant_field-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_rename_variant_field-5.snap
@@ -40,7 +40,7 @@ class ReflectapiDemoTestsSerdeTestEnumRenameVariantFieldVariant2Variant(BaseMode
     """Variant2 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     variant2_field_name: int

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestEnumTagVariant1(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Variant1"] = Field(
@@ -38,7 +38,7 @@ class ReflectapiDemoTestsSerdeTestEnumTagVariant1(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestEnumTagVariant2(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Variant2"] = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content-5.snap
@@ -29,7 +29,7 @@ class ReflectapiDemoTestsSerdeTestEnumTagContentVariant1Content(BaseModel):
     """Variant1 content"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_name: int
@@ -37,7 +37,7 @@ class ReflectapiDemoTestsSerdeTestEnumTagContentVariant1Content(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestEnumTagContentVariant1(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Variant1"] = Field(
@@ -50,7 +50,7 @@ class ReflectapiDemoTestsSerdeTestEnumTagContentVariant1(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestEnumTagContentVariant2(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Variant2"] = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content_rename_all-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_tag_content_rename_all-5.snap
@@ -29,7 +29,7 @@ class ReflectapiDemoTestsSerdeTestEnumTagContentRenameAllVariant1Content(BaseMod
     """variant1 content"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_name: int
@@ -37,7 +37,7 @@ class ReflectapiDemoTestsSerdeTestEnumTagContentRenameAllVariant1Content(BaseMod
 
 class ReflectapiDemoTestsSerdeTestEnumTagContentRenameAllVariant1(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["variant1"] = Field(
@@ -50,7 +50,7 @@ class ReflectapiDemoTestsSerdeTestEnumTagContentRenameAllVariant1(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestEnumTagContentRenameAllVariant2(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["variant2"] = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_untagged-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_untagged-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestEnumUntaggedVariant1(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     value: int
@@ -35,7 +35,7 @@ class ReflectapiDemoTestsSerdeTestEnumUntaggedVariant1(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestEnumUntaggedVariant2(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_name: int

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_field_skip-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_field_skip-5.snap
@@ -40,7 +40,7 @@ class ReflectapiDemoTestsSerdeTestEnumWithFieldSkipVariant1Variant(BaseModel):
     """Variant1 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_many_variants-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_many_variants-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeLargeEnumAlpha(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Alpha"] = Field(default="Alpha", description="Discriminator field")
@@ -35,7 +35,7 @@ class ReflectapiDemoTestsSerdeLargeEnumAlpha(BaseModel):
 
 class ReflectapiDemoTestsSerdeLargeEnumBeta(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Beta"] = Field(default="Beta", description="Discriminator field")
@@ -43,7 +43,7 @@ class ReflectapiDemoTestsSerdeLargeEnumBeta(BaseModel):
 
 class ReflectapiDemoTestsSerdeLargeEnumGamma(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Gamma"] = Field(default="Gamma", description="Discriminator field")
@@ -52,7 +52,7 @@ class ReflectapiDemoTestsSerdeLargeEnumGamma(BaseModel):
 
 class ReflectapiDemoTestsSerdeLargeEnumDelta(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Delta"] = Field(default="Delta", description="Discriminator field")
@@ -61,7 +61,7 @@ class ReflectapiDemoTestsSerdeLargeEnumDelta(BaseModel):
 
 class ReflectapiDemoTestsSerdeLargeEnumEpsilon(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Epsilon"] = Field(
@@ -71,7 +71,7 @@ class ReflectapiDemoTestsSerdeLargeEnumEpsilon(BaseModel):
 
 class ReflectapiDemoTestsSerdeLargeEnumZeta(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Zeta"] = Field(default="Zeta", description="Discriminator field")
@@ -80,7 +80,7 @@ class ReflectapiDemoTestsSerdeLargeEnumZeta(BaseModel):
 
 class ReflectapiDemoTestsSerdeLargeEnumEta(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Eta"] = Field(default="Eta", description="Discriminator field")
@@ -88,7 +88,7 @@ class ReflectapiDemoTestsSerdeLargeEnumEta(BaseModel):
 
 class ReflectapiDemoTestsSerdeLargeEnumTheta(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Theta"] = Field(default="Theta", description="Discriminator field")
@@ -97,7 +97,7 @@ class ReflectapiDemoTestsSerdeLargeEnumTheta(BaseModel):
 
 class ReflectapiDemoTestsSerdeLargeEnumIota(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Iota"] = Field(default="Iota", description="Discriminator field")
@@ -105,7 +105,7 @@ class ReflectapiDemoTestsSerdeLargeEnumIota(BaseModel):
 
 class ReflectapiDemoTestsSerdeLargeEnumKappa(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Kappa"] = Field(default="Kappa", description="Discriminator field")
@@ -114,7 +114,7 @@ class ReflectapiDemoTestsSerdeLargeEnumKappa(BaseModel):
 
 class ReflectapiDemoTestsSerdeLargeEnumLambda(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Lambda"] = Field(default="Lambda", description="Discriminator field")
@@ -122,7 +122,7 @@ class ReflectapiDemoTestsSerdeLargeEnumLambda(BaseModel):
 
 class ReflectapiDemoTestsSerdeLargeEnumMu(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Mu"] = Field(default="Mu", description="Discriminator field")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_rename_to_invalid_chars-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_rename_to_invalid_chars-5.snap
@@ -42,7 +42,7 @@ class ReflectapiDemoTestsSerdeTestEnumWithRenameToInvalidCharsVariant1Variant(
     """Variant1 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(serialization_alias="field-name&&", validation_alias="field-name&&")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_serde_rename_on_variants-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_serde_rename_on_variants-5.snap
@@ -29,7 +29,7 @@ class ReflectapiDemoTestsSerdeActionCreateItemContent(BaseModel):
     """create_item content"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     name: str
@@ -37,7 +37,7 @@ class ReflectapiDemoTestsSerdeActionCreateItemContent(BaseModel):
 
 class ReflectapiDemoTestsSerdeActionCreateItem(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     kind: Literal["create_item"] = Field(
@@ -52,7 +52,7 @@ class ReflectapiDemoTestsSerdeActionDeleteItemContent(BaseModel):
     """delete_item content"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     id: int
@@ -60,7 +60,7 @@ class ReflectapiDemoTestsSerdeActionDeleteItemContent(BaseModel):
 
 class ReflectapiDemoTestsSerdeActionDeleteItem(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     kind: Literal["delete_item"] = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_other-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_other-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeInputTestEnumWithVariantOtherV0(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["V0"] = Field(default="V0", description="Discriminator field")
@@ -42,7 +42,7 @@ class ReflectapiDemoTestsSerdeInputTestEnumWithVariantOther(RootModel):
 
 class ReflectapiDemoTestsSerdeOutputTestEnumWithVariantOtherV0(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["V0"] = Field(default="V0", description="Discriminator field")
@@ -50,7 +50,7 @@ class ReflectapiDemoTestsSerdeOutputTestEnumWithVariantOtherV0(BaseModel):
 
 class ReflectapiDemoTestsSerdeOutputTestEnumWithVariantOtherVariant1(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Variant1"] = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_untagged-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__enum_with_variant_untagged-5.snap
@@ -40,7 +40,7 @@ class ReflectapiDemoTestsSerdeTestEnumWithVariantUntaggedVariant1Variant(BaseMod
     """Variant1 variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: int

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__external_impls-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__external_impls-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTest(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     index_map: dict[int, int]

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__field_all_python_keywords-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__field_all_python_keywords-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeKeywords(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type_: str = Field(serialization_alias="type", validation_alias="type")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__field_names_with_special_chars-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__field_names_with_special_chars-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeSpecialNames(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     content_type: str = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_adjacently_tagged_enum_field-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_adjacently_tagged_enum_field-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeMessage(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     id: str
@@ -38,7 +38,7 @@ class ReflectapiDemoTestsSerdePayloadTextContent(BaseModel):
     """Text content"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     body: str
@@ -46,7 +46,7 @@ class ReflectapiDemoTestsSerdePayloadTextContent(BaseModel):
 
 class ReflectapiDemoTestsSerdePayloadText(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     kind: Literal["Text"] = Field(default="Text", description="Discriminator field")
@@ -57,7 +57,7 @@ class ReflectapiDemoTestsSerdePayloadBinaryContent(BaseModel):
     """Binary content"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     size: int
@@ -65,7 +65,7 @@ class ReflectapiDemoTestsSerdePayloadBinaryContent(BaseModel):
 
 class ReflectapiDemoTestsSerdePayloadBinary(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     kind: Literal["Binary"] = Field(default="Binary", description="Discriminator field")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_enum_with_unit_variants_only-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_enum_with_unit_variants_only-5.snap
@@ -29,7 +29,7 @@ class ReflectapiDemoTestsSerdeItemActive(BaseModel):
     """'Active' variant of ReflectapiDemoTestsSerdeItem"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     name: str
@@ -42,7 +42,7 @@ class ReflectapiDemoTestsSerdeItemInactive(BaseModel):
     """'Inactive' variant of ReflectapiDemoTestsSerdeItem"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     name: str
@@ -55,7 +55,7 @@ class ReflectapiDemoTestsSerdeItemPending(BaseModel):
     """'Pending' variant of ReflectapiDemoTestsSerdeItem"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     name: str
@@ -77,7 +77,7 @@ class ReflectapiDemoTestsSerdeItem(RootModel):
 
 class ReflectapiDemoTestsSerdeStatusActive(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     status: Literal["Active"] = Field(
@@ -87,7 +87,7 @@ class ReflectapiDemoTestsSerdeStatusActive(BaseModel):
 
 class ReflectapiDemoTestsSerdeStatusInactive(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     status: Literal["Inactive"] = Field(
@@ -97,7 +97,7 @@ class ReflectapiDemoTestsSerdeStatusInactive(BaseModel):
 
 class ReflectapiDemoTestsSerdeStatusPending(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     status: Literal["Pending"] = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_externally_tagged_enum_field-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_externally_tagged_enum_field-5.snap
@@ -38,7 +38,7 @@ from reflectapi_runtime import (
 
 class ReflectapiDemoTestsSerdeDrawing(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     name: str
@@ -49,7 +49,7 @@ class ReflectapiDemoTestsSerdeShapeCircleVariant(BaseModel):
     """Circle variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     radius: float
@@ -59,7 +59,7 @@ class ReflectapiDemoTestsSerdeShapeRectVariant(BaseModel):
     """Rect variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     width: float

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_internally_tagged-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_internally_tagged-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeA(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     a: int
@@ -35,7 +35,7 @@ class ReflectapiDemoTestsSerdeA(BaseModel):
 
 class ReflectapiDemoTestsSerdeB(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     b: int
@@ -45,7 +45,7 @@ class ReflectapiDemoTestsSerdeSReflectapiDemoTestsSerdeAReflectapiDemoTestsSerde
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     a: int
@@ -54,7 +54,7 @@ class ReflectapiDemoTestsSerdeSReflectapiDemoTestsSerdeAReflectapiDemoTestsSerde
 
 class ReflectapiDemoTestsSerdeTestS(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["S"] = Field(default="S", description="Discriminator field")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_internally_tagged_enum_field-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_internally_tagged_enum_field-5.snap
@@ -29,7 +29,7 @@ class ReflectapiDemoTestsSerdeOfferSingle(BaseModel):
     """'Single' variant of ReflectapiDemoTestsSerdeOffer"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     id: str
@@ -46,7 +46,7 @@ class ReflectapiDemoTestsSerdeOfferGroup(BaseModel):
     """'Group' variant of ReflectapiDemoTestsSerdeOffer"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     id: str
@@ -71,7 +71,7 @@ class ReflectapiDemoTestsSerdeOffer(RootModel):
 
 class ReflectapiDemoTestsSerdeOfferKindSingle(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Single"] = Field(default="Single", description="Discriminator field")
@@ -80,7 +80,7 @@ class ReflectapiDemoTestsSerdeOfferKindSingle(BaseModel):
 
 class ReflectapiDemoTestsSerdeOfferKindGroup(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Group"] = Field(default="Group", description="Discriminator field")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_multiple_structs-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_multiple_structs-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeDocument(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     title: str
@@ -38,7 +38,7 @@ class ReflectapiDemoTestsSerdeDocument(BaseModel):
 
 class ReflectapiDemoTestsSerdeMetadata(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     author: str
@@ -47,7 +47,7 @@ class ReflectapiDemoTestsSerdeMetadata(BaseModel):
 
 class ReflectapiDemoTestsSerdeTimestamps(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     created_at: str

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_optional_internally_tagged_enum-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_optional_internally_tagged_enum-5.snap
@@ -29,7 +29,7 @@ class ReflectapiDemoTestsSerdeTaskHigh(BaseModel):
     """'High' variant of ReflectapiDemoTestsSerdeTask"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     title: str
@@ -41,7 +41,7 @@ class ReflectapiDemoTestsSerdeTaskLow(BaseModel):
     """'Low' variant of ReflectapiDemoTestsSerdeTask"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     title: str
@@ -60,7 +60,7 @@ class ReflectapiDemoTestsSerdeTask(RootModel):
 
 class ReflectapiDemoTestsSerdePriorityHigh(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     kind: Literal["High"] = Field(default="High", description="Discriminator field")
@@ -69,7 +69,7 @@ class ReflectapiDemoTestsSerdePriorityHigh(BaseModel):
 
 class ReflectapiDemoTestsSerdePriorityLow(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     kind: Literal["Low"] = Field(default="Low", description="Discriminator field")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_struct_and_internal_enum_combined-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_struct_and_internal_enum_combined-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeAudit(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     modified_by: str
@@ -37,7 +37,7 @@ class ReflectapiDemoTestsSerdePostText(BaseModel):
     """'Text' variant of ReflectapiDemoTestsSerdePost"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     id: str
@@ -55,7 +55,7 @@ class ReflectapiDemoTestsSerdePostImage(BaseModel):
     """'Image' variant of ReflectapiDemoTestsSerdePost"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     id: str
@@ -82,7 +82,7 @@ class ReflectapiDemoTestsSerdePost(RootModel):
 
 class ReflectapiDemoTestsSerdeContentText(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Text"] = Field(default="Text", description="Discriminator field")
@@ -91,7 +91,7 @@ class ReflectapiDemoTestsSerdeContentText(BaseModel):
 
 class ReflectapiDemoTestsSerdeContentImage(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["Image"] = Field(default="Image", description="Discriminator field")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_struct_with_nested_flatten-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_struct_with_nested_flatten-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeInner(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     z: str
@@ -34,7 +34,7 @@ class ReflectapiDemoTestsSerdeInner(BaseModel):
 
 class ReflectapiDemoTestsSerdeMiddle(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     y: int
@@ -43,7 +43,7 @@ class ReflectapiDemoTestsSerdeMiddle(BaseModel):
 
 class ReflectapiDemoTestsSerdeOuter(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     x: str

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_unit-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_unit-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeK(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     a: int
@@ -34,7 +34,7 @@ class ReflectapiDemoTestsSerdeK(BaseModel):
 
 class ReflectapiDemoTestsSerdeSReflectapiDemoTestsSerdeKStdTuple0(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     a: int

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_untagged_enum_field-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__flatten_untagged_enum_field-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeCell(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     label: str
@@ -36,7 +36,7 @@ class ReflectapiDemoTestsSerdeCell(BaseModel):
 
 class ReflectapiDemoTestsSerdeValueNum(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     value: float
@@ -44,7 +44,7 @@ class ReflectapiDemoTestsSerdeValueNum(BaseModel):
 
 class ReflectapiDemoTestsSerdeValueText(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     text: str

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_adjacently_tagged_enum-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_adjacently_tagged_enum-5.snap
@@ -33,7 +33,7 @@ T = TypeVar("T")
 
 class ReflectapiDemoTestsSerdeTaggedItem(BaseModel, Generic[T]):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     t: Literal["Item"] = Field(default="Item", description="Discriminator field")
@@ -42,7 +42,7 @@ class ReflectapiDemoTestsSerdeTaggedItem(BaseModel, Generic[T]):
 
 class ReflectapiDemoTestsSerdeTaggedNothing(BaseModel, Generic[T]):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     t: Literal["Nothing"] = Field(default="Nothing", description="Discriminator field")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_externally_tagged_enum-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_externally_tagged_enum-5.snap
@@ -46,7 +46,7 @@ class ReflectapiDemoTestsSerdeWrapperValueVariant(BaseModel, Generic[T]):
     """Value variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: T

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_flatten_drops_inner_fields-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_flatten_drops_inner_fields-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestFlattenIfElse(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     code: int
@@ -35,7 +35,7 @@ class ReflectapiDemoTestsSerdeTestFlattenIfElse(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestFlattenInner(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     inner_a: int
@@ -46,7 +46,7 @@ class ReflectapiDemoTestsSerdeTestUpdateOrElseReflectapiDemoTestsSerdeTestFlatC4
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     if_else: reflectapi_demo.tests.serde.TestFlattenIfElse | None

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_flatten_enum_variant_typevar-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_flatten_enum_variant_typevar-5.snap
@@ -38,7 +38,7 @@ from reflectapi_runtime import (
 
 class ReflectapiDemoTestsSerdeTestFlattenIdent(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     job_id: int
@@ -46,7 +46,7 @@ class ReflectapiDemoTestsSerdeTestFlattenIdent(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestFlattenIdentData(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     payload: str
@@ -56,7 +56,7 @@ class ReflectapiDemoTestsSerdeTestIdentityDataReflectapiDemoTestsSerdeTestFlat59
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     job_id: int
@@ -69,7 +69,7 @@ class ReflectapiDemoTestsSerdeTestIngestRelationReflectapiDemoTestsSerdeTestFl36
     """Insert variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: reflectapi_demo.tests.serde.TestIdentityDataReflectapiDemoTestsSerdeTestFlat59f317e8
@@ -81,7 +81,7 @@ class ReflectapiDemoTestsSerdeTestIngestRelationReflectapiDemoTestsSerdeTestFl36
     """Remove variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: reflectapi_demo.tests.serde.TestIdentityDataReflectapiDemoTestsSerdeTestFlat59f317e8

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_flatten_leaf_collision-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_flatten_leaf_collision-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestFlattenIfElse(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     code: int
@@ -35,7 +35,7 @@ class ReflectapiDemoTestsSerdeTestFlattenIfElse(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestLeafCollisionPair(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     a: reflectapi_demo.tests.serde.TestUpdateOrElseReflectapiDemoTestsSerdeModuleAS0030345e
@@ -46,7 +46,7 @@ class ReflectapiDemoTestsSerdeTestUpdateOrElseReflectapiDemoTestsSerdeModuleAS00
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     if_else: reflectapi_demo.tests.serde.TestFlattenIfElse | None
@@ -57,7 +57,7 @@ class ReflectapiDemoTestsSerdeTestUpdateOrElseReflectapiDemoTestsSerdeModuleBSD4
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     if_else: reflectapi_demo.tests.serde.TestFlattenIfElse | None
@@ -66,7 +66,7 @@ class ReflectapiDemoTestsSerdeTestUpdateOrElseReflectapiDemoTestsSerdeModuleBSD4
 
 class ReflectapiDemoTestsSerdeModuleASample(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     a_field: int
@@ -74,7 +74,7 @@ class ReflectapiDemoTestsSerdeModuleASample(BaseModel):
 
 class ReflectapiDemoTestsSerdeModuleBSample(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     b_field: bool

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_flatten_nested-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_flatten_nested-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestFlattenIdent(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     job_id: int
@@ -35,7 +35,7 @@ class ReflectapiDemoTestsSerdeTestFlattenIdent(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestFlattenIdentData(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     payload: str
@@ -43,7 +43,7 @@ class ReflectapiDemoTestsSerdeTestFlattenIdentData(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestFlattenIfElse(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     code: int
@@ -53,7 +53,7 @@ class ReflectapiDemoTestsSerdeTestIdentityDataReflectapiDemoTestsSerdeTestFlat59
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     job_id: int
@@ -64,7 +64,7 @@ class ReflectapiDemoTestsSerdeTestUpdateOrElseReflectapiDemoTestsSerdeTestIden57
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     if_else: reflectapi_demo.tests.serde.TestFlattenIfElse | None

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_flatten_optional-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_flatten_optional-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestFlattenInner(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     inner_a: int
@@ -38,7 +38,7 @@ class ReflectapiDemoTestsSerdeInputTestOptionalFlattenReflectapiDemoTestsSerdeEe
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     code: int
@@ -50,7 +50,7 @@ class ReflectapiDemoTestsSerdeOutputTestOptionalFlattenReflectapiDemoTestsSerd85
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     code: int

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_flatten_two_instantiations-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_flatten_two_instantiations-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestFlattenIfElse(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     code: int
@@ -35,7 +35,7 @@ class ReflectapiDemoTestsSerdeTestFlattenIfElse(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestFlattenInner(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     inner_a: int
@@ -44,7 +44,7 @@ class ReflectapiDemoTestsSerdeTestFlattenInner(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestFlattenInnerAlt(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     alt_x: bool
@@ -52,7 +52,7 @@ class ReflectapiDemoTestsSerdeTestFlattenInnerAlt(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestTwoInstantiations(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     a: reflectapi_demo.tests.serde.TestUpdateOrElseReflectapiDemoTestsSerdeTestFlatC43b4b99
@@ -63,7 +63,7 @@ class ReflectapiDemoTestsSerdeTestUpdateOrElseReflectapiDemoTestsSerdeTestFlat7b
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     if_else: reflectapi_demo.tests.serde.TestFlattenIfElse | None
@@ -74,7 +74,7 @@ class ReflectapiDemoTestsSerdeTestUpdateOrElseReflectapiDemoTestsSerdeTestFlatC4
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     if_else: reflectapi_demo.tests.serde.TestFlattenIfElse | None

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_flatten_typevar_in_generic_context-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_flatten_typevar_in_generic_context-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestFlattenIdent(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     job_id: int
@@ -34,7 +34,7 @@ class ReflectapiDemoTestsSerdeTestFlattenIdent(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestFlattenIdentData(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     payload: str
@@ -44,7 +44,7 @@ class ReflectapiDemoTestsSerdeTestIdentityDataReflectapiDemoTestsSerdeTestFlat59
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     job_id: int
@@ -55,7 +55,7 @@ class ReflectapiDemoTestsSerdeTestWithMarkedInnerReflectapiDemoTestsSerdeTestFF1
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     body: reflectapi_demo.tests.serde.TestIdentityDataReflectapiDemoTestsSerdeTestFlat59f317e8

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_flatten_typevar_nested_in_generic_arg-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_flatten_typevar_nested_in_generic_arg-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestFlattenIfElse(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     code: int
@@ -35,7 +35,7 @@ class ReflectapiDemoTestsSerdeTestFlattenIfElse(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestFlattenInner(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     inner_a: int
@@ -46,7 +46,7 @@ class ReflectapiDemoTestsSerdeTestUpdateOrElseStdOptionReflectapiDemoTestsSerd2c
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     if_else: reflectapi_demo.tests.serde.TestFlattenIfElse | None
@@ -58,7 +58,7 @@ class ReflectapiDemoTestsSerdeTestWrapperWithNestedTypevarArgReflectapiDemoTes80
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     body: reflectapi_demo.tests.serde.TestUpdateOrElseStdOptionReflectapiDemoTestsSerd2c778819

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_with_concrete_flatten_not_marked-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__generic_with_concrete_flatten_not_marked-5.snap
@@ -34,7 +34,7 @@ class ReflectapiDemoTestsSerdeTestGenericWithConcreteFlattenReflectapiDemoTes_56
     BaseModel
 ):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     other: reflectapi_demo.tests.serde.TestFlattenIfElse
@@ -44,7 +44,7 @@ class ReflectapiDemoTestsSerdeTestGenericWithConcreteFlattenReflectapiDemoTes_56
 
 class ReflectapiDemoTestsSerdeTestFlattenIfElse(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     code: int
@@ -52,7 +52,7 @@ class ReflectapiDemoTestsSerdeTestFlattenIfElse(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestFlattenInner(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     inner_a: int
@@ -61,7 +61,7 @@ class ReflectapiDemoTestsSerdeTestFlattenInner(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestGenericWithConcreteFlatten(BaseModel, Generic[T]):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     other: T

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__kebab_case-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__kebab_case-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTest(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_name: int = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__multiple_underscore_prefix_fields-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__multiple_underscore_prefix_fields-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeUnderscored(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     single: int = Field(serialization_alias="_single", validation_alias="_single")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__namespace_deeply_nested_modules-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__namespace_deeply_nested_modules-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeDeepNestedInnerDeepType(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     data: str

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__namespace_single_segment_type-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__namespace_single_segment_type-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeSimpleTopLevel(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     value: int

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__namespace_with_numeric_start-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__namespace_with_numeric_start-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTypeWithNumbers(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_123: str = Field(serialization_alias="123start", validation_alias="123start")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__nested_generic_containers-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__nested_generic_containers-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeComplex(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     matrix: list[list[int]]

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__nested_internally_tagged_enums-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__nested_internally_tagged_enums-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestV1(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     version: Literal["v1"] = Field(default="v1", description="Discriminator field")
@@ -36,7 +36,7 @@ class ReflectapiDemoTestsSerdeTestV1(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestV2(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     version: Literal["v2"] = Field(default="v2", description="Discriminator field")
@@ -52,7 +52,7 @@ class ReflectapiDemoTestsSerdeTest(RootModel):
 
 class ReflectapiDemoTestsSerdeV1A(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["A"] = Field(default="A", description="Discriminator field")
@@ -61,7 +61,7 @@ class ReflectapiDemoTestsSerdeV1A(BaseModel):
 
 class ReflectapiDemoTestsSerdeV1B(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["B"] = Field(default="B", description="Discriminator field")
@@ -77,7 +77,7 @@ class ReflectapiDemoTestsSerdeV1(RootModel):
 
 class ReflectapiDemoTestsSerdeV2C(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["C"] = Field(default="C", description="Discriminator field")
@@ -86,7 +86,7 @@ class ReflectapiDemoTestsSerdeV2C(BaseModel):
 
 class ReflectapiDemoTestsSerdeV2D(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["D"] = Field(default="D", description="Discriminator field")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__nested_internally_tagged_enums_minimal-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__nested_internally_tagged_enums_minimal-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestV1(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     version: Literal["v1"] = Field(default="v1", description="Discriminator field")
@@ -42,7 +42,7 @@ class ReflectapiDemoTestsSerdeTest(RootModel):
 
 class ReflectapiDemoTestsSerdeV1A(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["A"] = Field(default="A", description="Discriminator field")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__newtype_variants_adjacently_tagged-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__newtype_variants_adjacently_tagged-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestNewtypeVariantsAdjacentlyTaggedInt(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     t: Literal["int"] = Field(default="int", description="Discriminator field")
@@ -36,7 +36,7 @@ class ReflectapiDemoTestsSerdeTestNewtypeVariantsAdjacentlyTaggedInt(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestNewtypeVariantsAdjacentlyTaggedString(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     t: Literal["string"] = Field(default="string", description="Discriminator field")
@@ -45,7 +45,7 @@ class ReflectapiDemoTestsSerdeTestNewtypeVariantsAdjacentlyTaggedString(BaseMode
 
 class ReflectapiDemoTestsSerdeTestNewtypeVariantsAdjacentlyTaggedBool(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     t: Literal["bool"] = Field(default="bool", description="Discriminator field")
@@ -54,7 +54,7 @@ class ReflectapiDemoTestsSerdeTestNewtypeVariantsAdjacentlyTaggedBool(BaseModel)
 
 class ReflectapiDemoTestsSerdeTestNewtypeVariantsAdjacentlyTaggedUnit(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     t: Literal["unit"] = Field(default="unit", description="Discriminator field")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__newtype_variants_externally_tagged-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__newtype_variants_externally_tagged-5.snap
@@ -40,7 +40,7 @@ class ReflectapiDemoTestsSerdeTestNewtypeVariantsExternallyTaggedIntVariant(Base
     """int variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: int
@@ -52,7 +52,7 @@ class ReflectapiDemoTestsSerdeTestNewtypeVariantsExternallyTaggedStringVariant(
     """string variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: str
@@ -62,7 +62,7 @@ class ReflectapiDemoTestsSerdeTestNewtypeVariantsExternallyTaggedBoolVariant(Bas
     """bool variant"""
 
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_0: bool

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__newtype_variants_internally_tagged-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__newtype_variants_internally_tagged-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeStrukt1(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     a: int
@@ -36,7 +36,7 @@ class ReflectapiDemoTestsSerdeStrukt1(BaseModel):
 
 class ReflectapiDemoTestsSerdeStrukt2(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     c: int
@@ -45,7 +45,7 @@ class ReflectapiDemoTestsSerdeStrukt2(BaseModel):
 
 class ReflectapiDemoTestsSerdeEnumA(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["a"] = Field(default="a", description="Discriminator field")
@@ -55,7 +55,7 @@ class ReflectapiDemoTestsSerdeEnumA(BaseModel):
 
 class ReflectapiDemoTestsSerdeEnumB(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     type: Literal["b"] = Field(default="b", description="Discriminator field")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__option_of_option-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__option_of_option-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeNested(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     value: str | None | None = None

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__self_referential_struct-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__self_referential_struct-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeCategory(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     name: str

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_from-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_from-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestStructFrom(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int
@@ -34,7 +34,7 @@ class ReflectapiDemoTestsSerdeTestStructFrom(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestStructFromProxy(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_into-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_into-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestStructInto(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int
@@ -34,7 +34,7 @@ class ReflectapiDemoTestsSerdeTestStructInto(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestStructIntoProxy(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeMyStruct(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestStructRenameAll(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_name: int = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_differently-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_differently-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeInputTestStructRenameAllDifferently(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_name: int
@@ -34,7 +34,7 @@ class ReflectapiDemoTestsSerdeInputTestStructRenameAllDifferently(BaseModel):
 
 class ReflectapiDemoTestsSerdeOutputTestStructRenameAllDifferently(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_name: int = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_pascal_case-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_all_pascal_case-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestStructRenameAllPascalCase(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_name: int = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_differently-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_differently-5.snap
@@ -26,13 +26,13 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeMyStructInput(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
 
 class ReflectapiDemoTestsSerdeMyStructOutput(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_field-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_rename_field-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeInputTestStructRenameField(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_name: int = Field(
@@ -36,7 +36,7 @@ class ReflectapiDemoTestsSerdeInputTestStructRenameField(BaseModel):
 
 class ReflectapiDemoTestsSerdeOutputTestStructRenameField(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_name: int

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_repr_transparent_generic_inner_type-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_repr_transparent_generic_inner_type-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTest(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     inner: list[int]

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_try_from-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_try_from-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestStructTryFormProxy(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int
@@ -34,7 +34,7 @@ class ReflectapiDemoTestsSerdeTestStructTryFormProxy(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestStructTryFrom(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestStructWithFlatten(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int
@@ -34,7 +34,7 @@ class ReflectapiDemoTestsSerdeTestStructWithFlatten(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestStructWithFlattenNested(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestStructWithFlattenNested(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int
@@ -35,7 +35,7 @@ class ReflectapiDemoTestsSerdeTestStructWithFlattenNested(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestStructWithFlattenOptional(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int | None = None

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional_and_required-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_flatten_optional_and_required-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestStructRenameAll(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_name: int = Field(
@@ -37,7 +37,7 @@ class ReflectapiDemoTestsSerdeTestStructRenameAll(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestStructWithFlattenNested(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int
@@ -45,7 +45,7 @@ class ReflectapiDemoTestsSerdeTestStructWithFlattenNested(BaseModel):
 
 class ReflectapiDemoTestsSerdeTestStructWithFlattenOptionalAndRequired(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int | None = None

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_invalid_chars-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_invalid_chars-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestStructWithRenameToInvalidChars(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(serialization_alias="field-name&&", validation_alias="field-name&&")

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_kebab_case-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_rename_to_kebab_case-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeStructName(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     field_name: int = Field(

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_default-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_default-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeInputTestStructWithSerdeDefault(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int | None = None
@@ -34,7 +34,7 @@ class ReflectapiDemoTestsSerdeInputTestStructWithSerdeDefault(BaseModel):
 
 class ReflectapiDemoTestsSerdeOutputTestStructWithSerdeDefault(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestStructWithSerdeSkip(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_deserialize-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_deserialize-5.snap
@@ -26,13 +26,13 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeInputTestStructWithSerdeSkipDeserialize(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
 
 class ReflectapiDemoTestsSerdeOutputTestStructWithSerdeSkipDeserialize(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeInputTestStructWithSerdeSkipSerialize(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int = Field(serialization_alias="_f", validation_alias="_f")
@@ -34,7 +34,7 @@ class ReflectapiDemoTestsSerdeInputTestStructWithSerdeSkipSerialize(BaseModel):
 
 class ReflectapiDemoTestsSerdeOutputTestStructWithSerdeSkipSerialize(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
 

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize_if-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__struct_with_serde_skip_serialize_if-5.snap
@@ -27,7 +27,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeInputTestStructWithSerdeSkipSerializeIf(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int | None = None
@@ -35,7 +35,7 @@ class ReflectapiDemoTestsSerdeInputTestStructWithSerdeSkipSerializeIf(BaseModel)
 
 class ReflectapiDemoTestsSerdeOutputTestStructWithSerdeSkipSerializeIf(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     f: int | None = None

--- a/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__timezone-5.snap
+++ b/reflectapi-demo/src/tests/snapshots/reflectapi_demo__tests__serde__timezone-5.snap
@@ -26,7 +26,7 @@ from reflectapi_runtime import ReflectapiInfallible
 
 class ReflectapiDemoTestsSerdeTestStruct(BaseModel):
     model_config = ConfigDict(
-        extra="ignore", populate_by_name=True, protected_namespaces=()
+        extra="ignore", populate_by_name=True, protected_namespaces=(), defer_build=True
     )
 
     timezone: str

--- a/reflectapi-demo/tests/codegen_coverage.rs
+++ b/reflectapi-demo/tests/codegen_coverage.rs
@@ -267,6 +267,7 @@ mod coverage {
     // ---- Docstring with characters that need escaping ----
     /// A docstring with "quotes" and 'apostrophes' and a backslash: \\
     /// And a """triple quote""" inside.
+    /// Ends in a "quote"
     #[derive(
         Debug, Clone, serde::Serialize, serde::Deserialize, reflectapi::Input, reflectapi::Output,
     )]

--- a/reflectapi/src/codegen/python.rs
+++ b/reflectapi/src/codegen/python.rs
@@ -6,10 +6,11 @@ use crate::{Schema, TypeReference};
 use reflectapi_schema::{Function, OutputType, Type};
 
 /// Sanitize text for inclusion in a Python triple-quoted docstring.
-/// Escapes backslashes (which act as line continuation) and triple-quote
-/// sequences (which would close the docstring prematurely).
+/// Escapes backslashes (which can escape the closing delimiter) and double
+/// quotes (which would otherwise collide with adjacent triple-quote
+/// delimiters).
 fn sanitize_for_docstring(text: &str) -> String {
-    text.replace('\\', "\\\\").replace("\"\"\"", "\\\"\\\"\\\"")
+    text.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 /// Format ``text`` as a Python string literal, choosing single or
@@ -7209,8 +7210,22 @@ fn pascal_case_len(s: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_python_class_name_map, generate_init_py, mangle_monomorphized_name, Config};
+    use super::{
+        build_python_class_name_map, generate_init_py, mangle_monomorphized_name,
+        sanitize_for_docstring, Config,
+    };
     use crate::TypeReference;
+
+    #[test]
+    fn docstring_sanitizer_escapes_quotes_that_touch_delimiters() {
+        let doc = "ends in a \"quote\"";
+        let sanitized = sanitize_for_docstring(doc);
+        let rendered = format!("\"\"\"{sanitized}\"\"\"");
+
+        assert_eq!(sanitized, "ends in a \\\"quote\\\"");
+        assert_eq!(rendered, "\"\"\"ends in a \\\"quote\\\"\"\"\"");
+        assert!(!rendered.contains("\"quote\"\"\"\""));
+    }
 
     #[test]
     fn python_init_exports_client() {

--- a/reflectapi/src/codegen/python.rs
+++ b/reflectapi/src/codegen/python.rs
@@ -692,6 +692,7 @@ fn render_struct_with_flatten(
             &tag,
             schema,
             implemented_types,
+            class_names,
             &active_generics,
             used_type_vars,
         )
@@ -702,6 +703,7 @@ fn render_struct_with_flatten(
             &struct_name,
             schema,
             implemented_types,
+            class_names,
             &active_generics,
             used_type_vars,
         )
@@ -729,6 +731,7 @@ fn render_struct_with_flattened_internal_enum(
     tag: &str,
     schema: &Schema,
     implemented_types: &BTreeMap<String, String>,
+    class_names: &BTreeMap<String, String>,
     active_generics: &[String],
     used_type_vars: &mut BTreeSet<String>,
 ) -> anyhow::Result<String> {
@@ -745,6 +748,7 @@ fn render_struct_with_flattened_internal_enum(
             &field.type_ref,
             schema,
             implemented_types,
+            class_names,
             active_generics,
             used_type_vars,
         )?;
@@ -777,6 +781,7 @@ fn render_struct_with_flattened_internal_enum(
                 &field.type_ref,
                 schema,
                 implemented_types,
+                class_names,
                 active_generics,
                 field.required,
                 0,
@@ -797,6 +802,7 @@ fn render_struct_with_flattened_internal_enum(
                     &field.type_ref,
                     schema,
                     implemented_types,
+                    class_names,
                     active_generics,
                     used_type_vars,
                 )?;
@@ -855,6 +861,7 @@ fn render_struct_with_flattened_internal_enum(
                         &vf.type_ref,
                         schema,
                         implemented_types,
+                        class_names,
                         active_generics,
                         used_type_vars,
                     )?;
@@ -900,6 +907,7 @@ fn render_struct_with_flattened_internal_enum(
                                 &sf.type_ref,
                                 schema,
                                 implemented_types,
+                                class_names,
                                 active_generics,
                                 sf.required,
                                 0,
@@ -913,6 +921,7 @@ fn render_struct_with_flattened_internal_enum(
                             &sf.type_ref,
                             schema,
                             implemented_types,
+                            class_names,
                             active_generics,
                             used_type_vars,
                         )?;
@@ -990,6 +999,7 @@ fn render_struct_with_flatten_standard(
     struct_name: &str,
     schema: &Schema,
     implemented_types: &BTreeMap<String, String>,
+    class_names: &BTreeMap<String, String>,
     active_generics: &[String],
     used_type_vars: &mut BTreeSet<String>,
 ) -> anyhow::Result<String> {
@@ -1002,6 +1012,7 @@ fn render_struct_with_flatten_standard(
             &field.type_ref,
             schema,
             implemented_types,
+            class_names,
             active_generics,
             used_type_vars,
         )?;
@@ -1033,6 +1044,7 @@ fn render_struct_with_flatten_standard(
             &field.type_ref,
             schema,
             implemented_types,
+            class_names,
             active_generics,
             field.required,
             0,
@@ -1834,7 +1846,8 @@ fn build_python_generation(
             Some(f) => f,
             None => continue,
         };
-        let rendered_function = render_function(function_schema, &schema, &implemented_types)?;
+        let rendered_function =
+            render_function(function_schema, &schema, &implemented_types, &class_names)?;
 
         // Check for grouping patterns: underscore or dot notation
         if let Some(separator_pos) = sem_func.name.find('_').or_else(|| sem_func.name.find('.')) {
@@ -1894,7 +1907,7 @@ fn build_python_generation(
         // Note types with fallbacks to primitives are not added.
         let mut user_defined_types: Vec<String> = rendered_type_keys
             .iter()
-            .map(|original_name| type_name_to_python_ref(original_name))
+            .map(|original_name| type_name_to_python_ref(original_name, &class_names))
             .collect();
         user_defined_types.sort();
 
@@ -3078,6 +3091,7 @@ fn collect_flattened_fields(
     type_ref: &TypeReference,
     schema: &Schema,
     implemented_types: &BTreeMap<String, String>,
+    class_names: &BTreeMap<String, String>,
     active_generics: &[String],
     parent_required: bool,
     depth: usize,
@@ -3120,6 +3134,7 @@ fn collect_flattened_fields(
                         &field.type_ref,
                         schema,
                         implemented_types,
+                        class_names,
                         active_generics,
                         parent_required && field.required,
                         depth + 1,
@@ -3133,6 +3148,7 @@ fn collect_flattened_fields(
                         field,
                         schema,
                         implemented_types,
+                        class_names,
                         active_generics,
                         parent_required,
                         depth,
@@ -3152,6 +3168,7 @@ fn collect_flattened_fields(
                 type_ref,
                 schema,
                 implemented_types,
+                class_names,
                 active_generics,
                 parent_required,
                 used_type_vars,
@@ -3195,6 +3212,7 @@ fn make_flattened_field(
     field: &reflectapi_schema::Field,
     schema: &Schema,
     implemented_types: &BTreeMap<String, String>,
+    class_names: &BTreeMap<String, String>,
     active_generics: &[String],
     parent_required: bool,
     depth: usize,
@@ -3204,6 +3222,7 @@ fn make_flattened_field(
         &field.type_ref,
         schema,
         implemented_types,
+        class_names,
         active_generics,
         used_type_vars,
     )?;
@@ -3248,6 +3267,7 @@ fn collect_flattened_enum_fields(
     type_ref: &TypeReference,
     schema: &Schema,
     implemented_types: &BTreeMap<String, String>,
+    class_names: &BTreeMap<String, String>,
     active_generics: &[String],
     parent_required: bool,
     used_type_vars: &mut BTreeSet<String>,
@@ -3258,6 +3278,7 @@ fn collect_flattened_enum_fields(
         type_ref,
         schema,
         implemented_types,
+        class_names,
         active_generics,
         used_type_vars,
     )?;
@@ -3346,6 +3367,7 @@ fn render_struct(
                 &field.type_ref,
                 schema,
                 implemented_types,
+                class_names,
                 &active_generics,
                 used_type_vars,
             )?;
@@ -3549,6 +3571,7 @@ fn render_adjacently_tagged_enum(
                         &unnamed_fields[0].type_ref,
                         schema,
                         implemented_types,
+                        class_names,
                         &generic_params,
                         used_type_vars,
                     )?;
@@ -3571,6 +3594,7 @@ fn render_adjacently_tagged_enum(
                             &f.type_ref,
                             schema,
                             implemented_types,
+                            class_names,
                             &generic_params,
                             used_type_vars,
                         )?;
@@ -3598,6 +3622,7 @@ fn render_adjacently_tagged_enum(
                         &field.type_ref,
                         schema,
                         implemented_types,
+                        class_names,
                         &generic_params,
                         used_type_vars,
                     )?;
@@ -3759,6 +3784,7 @@ fn render_externally_tagged_enum(
                         &field.type_ref,
                         schema,
                         implemented_types,
+                        class_names,
                         &generic_params,
                         used_type_vars,
                     )?;
@@ -3836,6 +3862,7 @@ fn render_externally_tagged_enum(
                         &field.type_ref,
                         schema,
                         implemented_types,
+                        class_names,
                         &generic_params,
                         used_type_vars,
                     )?;
@@ -4057,6 +4084,7 @@ fn render_internally_tagged_enum(
                                     &struct_field.type_ref,
                                     schema,
                                     implemented_types,
+                                    class_names,
                                     &generic_params,
                                     struct_field.required,
                                     0,
@@ -4070,6 +4098,7 @@ fn render_internally_tagged_enum(
                                 &struct_field.type_ref,
                                 schema,
                                 implemented_types,
+                                class_names,
                                 &generic_params,
                                 used_type_vars,
                             )?;
@@ -4105,6 +4134,7 @@ fn render_internally_tagged_enum(
                             &inner_field.type_ref,
                             schema,
                             implemented_types,
+                            class_names,
                             &generic_params,
                             used_type_vars,
                         )?;
@@ -4130,6 +4160,7 @@ fn render_internally_tagged_enum(
                         &field.type_ref,
                         schema,
                         implemented_types,
+                        class_names,
                         &generic_params,
                         used_type_vars,
                     )?;
@@ -4275,6 +4306,7 @@ fn render_untagged_enum(
                         &field.type_ref,
                         schema,
                         implemented_types,
+                        class_names,
                         &generic_params,
                         used_type_vars,
                     )?;
@@ -4303,6 +4335,7 @@ fn render_untagged_enum(
                         &field.type_ref,
                         schema,
                         implemented_types,
+                        class_names,
                         &generic_params,
                         used_type_vars,
                     )?;
@@ -4377,9 +4410,10 @@ fn render_function(
     function: &Function,
     schema: &Schema,
     implemented_types: &BTreeMap<String, String>,
+    class_names: &BTreeMap<String, String>,
 ) -> anyhow::Result<templates::Function> {
     let input_type = if let Some(input_type) = function.input_type.as_ref() {
-        type_ref_to_python_type_simple(input_type, schema, implemented_types, &[])?
+        type_ref_to_python_type_simple(input_type, schema, implemented_types, class_names, &[])?
     } else {
         "None".to_string()
     };
@@ -4388,13 +4422,24 @@ fn render_function(
         OutputType::Complete {
             output_type: Some(output_type),
         } => (
-            type_ref_to_python_type_simple(output_type, schema, implemented_types, &[])?,
+            type_ref_to_python_type_simple(
+                output_type,
+                schema,
+                implemented_types,
+                class_names,
+                &[],
+            )?,
             None,
         ),
         OutputType::Complete { output_type: None } => ("Any".to_string(), None),
         OutputType::Stream { item_type } => {
-            let item_py =
-                type_ref_to_python_type_simple(item_type, schema, implemented_types, &[])?;
+            let item_py = type_ref_to_python_type_simple(
+                item_type,
+                schema,
+                implemented_types,
+                class_names,
+                &[],
+            )?;
             (item_py.clone(), Some(item_py))
         }
     };
@@ -4404,6 +4449,7 @@ fn render_function(
             error_type,
             schema,
             implemented_types,
+            class_names,
             &[],
         )?)
     } else {
@@ -4416,6 +4462,7 @@ fn render_function(
             headers_ref,
             schema,
             implemented_types,
+            class_names,
             &[],
         )?)
     } else {
@@ -4814,31 +4861,46 @@ fn python_class_name(type_name: &str, class_names: &BTreeMap<String, String>) ->
         .unwrap_or_else(|| build_flat_python_class_name(type_name, true))
 }
 
-fn improve_class_name(original_name: &str) -> String {
-    build_flat_python_class_name(original_name, true)
-}
-
 /// Convert a fully-qualified Rust type name to a dotted Python reference.
 ///
-/// Each `::` segment becomes a dot-separated component.  Namespace segments
-/// keep their original casing (typically snake_case), while the final leaf
-/// segment is run through `improve_class_name_part` (PascalCase).
+/// Namespace segments become module components, while the class leaf comes
+/// from the same resolved class-name map used to render the actual Pydantic
+/// class. This keeps references aligned with de-stuttering, collision fallback,
+/// and long-name hash truncation.
 ///
-/// Example: `"reflectapi_demo::tests::serde::Offer"` → `"reflectapi_demo.tests.serde.Offer"`
-fn type_name_to_python_ref(original_name: &str) -> String {
+/// Example: `"billing::ProductDetailItem"` → `"billing.ProductDetailItem"`.
+fn type_name_to_python_ref(original_name: &str, class_names: &BTreeMap<String, String>) -> String {
     let parts: Vec<&str> = original_name.split("::").collect();
     if parts.len() <= 1 {
         // No namespace — just return the PascalCase leaf.
-        return improve_class_name(original_name);
+        return python_class_name(original_name, class_names);
     }
-    // Namespace segments keep their original casing; the leaf gets PascalCase.
+    // Namespace segments keep their original casing. The leaf should match a
+    // public alias exposed by that namespace module, not necessarily the flat
+    // implementation class name.
     let namespace_parts = &parts[..parts.len() - 1];
     let leaf = parts.last().unwrap();
     let mut dotted_parts: Vec<String> = namespace_parts
         .iter()
         .map(|p| safe_python_module_segment(p))
         .collect();
-    dotted_parts.push(improve_class_name_part(leaf));
+    let class_name = python_class_name(original_name, class_names);
+    let rust_leaf_alias = improve_class_name_part(leaf);
+    let leaf_alias = if class_name.ends_with(&to_pascal_case(leaf)) {
+        rust_leaf_alias
+    } else {
+        let namespace_path = namespace_parts
+            .iter()
+            .map(|part| (*part).to_string())
+            .collect::<Vec<_>>();
+        let flat_prefix = flat_namespace_prefix(&namespace_path);
+        if class_name.starts_with(&flat_prefix) {
+            class_name[flat_prefix.len()..].to_string()
+        } else {
+            class_name
+        }
+    };
+    dotted_parts.push(leaf_alias);
     dotted_parts.join(".")
 }
 
@@ -5005,6 +5067,7 @@ fn type_ref_to_python_type(
     type_ref: &TypeReference,
     schema: &Schema,
     implemented_types: &BTreeMap<String, String>,
+    class_names: &BTreeMap<String, String>,
     active_generics: &[String],
     used_type_vars: &mut BTreeSet<String>,
 ) -> anyhow::Result<String> {
@@ -5052,6 +5115,7 @@ fn type_ref_to_python_type(
                     arg,
                     schema,
                     implemented_types,
+                    class_names,
                     active_generics,
                     used_type_vars,
                 )?;
@@ -5069,6 +5133,7 @@ fn type_ref_to_python_type(
                         arg,
                         schema,
                         implemented_types,
+                        class_names,
                         active_generics,
                         used_type_vars,
                     )
@@ -5092,6 +5157,7 @@ fn type_ref_to_python_type(
             &fallback_type_ref,
             schema,
             implemented_types,
+            class_names,
             active_generics,
             used_type_vars,
         );
@@ -5118,6 +5184,7 @@ fn type_ref_to_python_type(
                     &inner_field.type_ref,
                     schema,
                     implemented_types,
+                    class_names,
                     active_generics,
                     used_type_vars,
                 );
@@ -5125,7 +5192,7 @@ fn type_ref_to_python_type(
         }
 
         // Use dotted namespace path for type references (e.g. "mod::Sub::Ty" → "mod.Sub.Ty")
-        let base_type = type_name_to_python_ref(&type_ref.name);
+        let base_type = type_name_to_python_ref(&type_ref.name, class_names);
 
         // Handle generic types with arguments - follow TypeScript pattern
         if !type_ref.arguments.is_empty() {
@@ -5141,6 +5208,7 @@ fn type_ref_to_python_type(
                         arg,
                         schema,
                         implemented_types,
+                        class_names,
                         active_generics,
                         used_type_vars,
                     )
@@ -5166,6 +5234,7 @@ fn type_ref_to_python_type_simple(
     type_ref: &TypeReference,
     schema: &Schema,
     implemented_types: &BTreeMap<String, String>,
+    class_names: &BTreeMap<String, String>,
     active_generics: &[String],
 ) -> anyhow::Result<String> {
     let mut unused_type_vars = BTreeSet::new();
@@ -5173,6 +5242,7 @@ fn type_ref_to_python_type_simple(
         type_ref,
         schema,
         implemented_types,
+        class_names,
         active_generics,
         &mut unused_type_vars,
     )

--- a/reflectapi/src/codegen/python.rs
+++ b/reflectapi/src/codegen/python.rs
@@ -2167,6 +2167,217 @@ fn root_module(ns_path: &[String]) -> String {
     safe_python_module_segment(&ns_path[0])
 }
 
+fn module_qualified_name(ns_path: &[String]) -> String {
+    ns_path
+        .iter()
+        .map(|segment| safe_python_module_segment(segment))
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+fn contains_qualified_name(code: &str, name: &str) -> bool {
+    let needle = format!("{name}.");
+    code.match_indices(&needle).any(|(index, _)| {
+        let before_is_boundary = index == 0
+            || code[..index]
+                .chars()
+                .next_back()
+                .is_none_or(|c| !(c.is_ascii_alphanumeric() || c == '_'));
+        let after_index = index + needle.len();
+        let after_is_boundary = code[after_index..]
+            .chars()
+            .next()
+            .is_none_or(|c| c.is_ascii_alphabetic() || c == '_');
+        before_is_boundary && after_is_boundary
+    })
+}
+
+fn strip_qualified_prefix(code: &str, prefix: &str) -> String {
+    let needle = format!("{prefix}.");
+    let mut output = String::with_capacity(code.len());
+    let mut cursor = 0;
+
+    for (index, _) in code.match_indices(&needle) {
+        let before_is_boundary = index == 0
+            || code[..index]
+                .chars()
+                .next_back()
+                .is_none_or(|c| !(c.is_ascii_alphanumeric() || c == '_'));
+        let after_index = index + needle.len();
+        let after_is_boundary = code[after_index..]
+            .chars()
+            .next()
+            .is_none_or(|c| c.is_ascii_alphabetic() || c == '_');
+
+        if before_is_boundary && after_is_boundary {
+            output.push_str(&code[cursor..index]);
+            cursor = after_index;
+        }
+    }
+
+    output.push_str(&code[cursor..]);
+    output
+}
+
+fn localize_current_module_refs(code: &str, ns_path: &[String]) -> String {
+    if ns_path.is_empty() {
+        return code.to_string();
+    }
+
+    strip_qualified_prefix(code, &module_qualified_name(ns_path))
+}
+
+fn module_rendered_code(module: &templates::Module) -> String {
+    module
+        .types
+        .iter()
+        .map(|mt| mt.rendered.as_str())
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn referenced_namespace_roots(
+    generation: &PythonGeneration,
+    rendered_code: &str,
+) -> BTreeSet<String> {
+    generation
+        .module_tree
+        .submodules
+        .values()
+        .filter(|sub| !sub.is_empty())
+        .map(|sub| safe_python_module_segment(&sub.name))
+        .filter(|root| contains_qualified_name(rendered_code, root))
+        .collect()
+}
+
+fn render_namespace_bindings(module: &templates::Module, ns_path: &[String]) -> String {
+    if ns_path.is_empty() {
+        return String::new();
+    }
+
+    let rendered_code = module_rendered_code(module);
+    let current_module = module_qualified_name(ns_path);
+    let references_current_module = contains_qualified_name(&rendered_code, &current_module);
+
+    if !references_current_module {
+        return String::new();
+    }
+
+    let mut lines = Vec::new();
+    lines.push("import sys".to_string());
+    if ns_path.len() > 1 {
+        lines.push(format!(
+            "from {} import {}",
+            root_relative_prefix(ns_path.len()),
+            root_module(ns_path)
+        ));
+    }
+    lines.push(format!("{current_module} = sys.modules[__name__]"));
+
+    lines.join("\n")
+}
+
+fn render_deferred_namespace_imports(
+    generation: &PythonGeneration,
+    module: &templates::Module,
+    ns_path: &[String],
+) -> String {
+    if ns_path.is_empty() {
+        return String::new();
+    }
+
+    let rendered_code = module_rendered_code(module);
+    let current_root = root_module(ns_path);
+    let referenced_roots: Vec<String> = referenced_namespace_roots(generation, &rendered_code)
+        .into_iter()
+        .filter(|root| root != &current_root)
+        .collect();
+
+    if referenced_roots.is_empty() {
+        return String::new();
+    }
+
+    format!(
+        "from {} import {}",
+        root_relative_prefix(ns_path.len()),
+        referenced_roots.join(", ")
+    )
+}
+
+fn deferred_namespace_names(
+    generation: &PythonGeneration,
+    module: &templates::Module,
+    ns_path: &[String],
+) -> BTreeSet<String> {
+    if ns_path.is_empty() {
+        return BTreeSet::new();
+    }
+
+    let rendered_code = module_rendered_code(module);
+    let current_root = root_module(ns_path);
+    let mut names: BTreeSet<String> = referenced_namespace_roots(generation, &rendered_code)
+        .into_iter()
+        .filter(|root| root != &current_root)
+        .collect();
+
+    names.extend(
+        module
+            .submodules
+            .values()
+            .filter(|sub| !sub.is_empty())
+            .map(|sub| safe_python_module_segment(&sub.name))
+            .filter(|child| contains_qualified_name(&rendered_code, child)),
+    );
+
+    names
+}
+
+fn render_deferred_namespace_placeholders(
+    generation: &PythonGeneration,
+    module: &templates::Module,
+    ns_path: &[String],
+) -> String {
+    let names = deferred_namespace_names(generation, module, ns_path);
+    if names.is_empty() {
+        return String::new();
+    }
+
+    let mut lines = vec![
+        "class _ReflectapiDeferredNamespace:".to_string(),
+        "    def __getattr__(self, name: str) -> None:".to_string(),
+        "        raise NameError(name)".to_string(),
+    ];
+    lines.extend(
+        names
+            .into_iter()
+            .map(|name| format!("{name} = _ReflectapiDeferredNamespace()")),
+    );
+    lines.join("\n")
+}
+
+fn render_root_type_namespace_bindings(
+    generation: &PythonGeneration,
+    rendered_code: &str,
+) -> String {
+    let referenced_roots: Vec<String> = generation
+        .module_tree
+        .submodules
+        .values()
+        .filter(|sub| !sub.is_empty())
+        .map(|sub| safe_python_module_segment(&sub.name))
+        .filter(|root| contains_qualified_name(rendered_code, root))
+        .collect();
+
+    if referenced_roots.is_empty() {
+        return String::new();
+    }
+
+    format!(
+        "from typing import TYPE_CHECKING\n\nif TYPE_CHECKING:\n    from . import {}",
+        referenced_roots.join(", ")
+    )
+}
+
 fn relative_module_import_path(ns_path: &[String]) -> String {
     format!(".{}", module_import_path(ns_path))
 }
@@ -2199,7 +2410,14 @@ fn render_module_file(
     root_type_names: &BTreeSet<String>,
     config: &Config,
 ) -> anyhow::Result<String> {
-    let mut parts = vec![generation.preamble.clone(), render_external_type_aliases()];
+    let mut parts = vec![generation.preamble.clone()];
+
+    let namespace_bindings = render_namespace_bindings(module, ns_path);
+    if !namespace_bindings.is_empty() {
+        parts.push(namespace_bindings);
+    }
+
+    parts.push(render_external_type_aliases());
 
     if !root_type_names.is_empty() {
         parts.push(format!(
@@ -2213,9 +2431,15 @@ fn render_module_file(
         ));
     }
 
+    let deferred_namespace_placeholders =
+        render_deferred_namespace_placeholders(generation, module, ns_path);
+    if !deferred_namespace_placeholders.is_empty() {
+        parts.push(deferred_namespace_placeholders);
+    }
+
     let mut body = String::new();
     for mt in &module.types {
-        body.push_str(&mt.rendered);
+        body.push_str(&localize_current_module_refs(&mt.rendered, ns_path));
         body.push('\n');
     }
 
@@ -2232,6 +2456,15 @@ fn render_module_file(
         }
     }
 
+    let deferred_namespace_imports = render_deferred_namespace_imports(generation, module, ns_path);
+    if !deferred_namespace_imports.is_empty() {
+        if !body.trim().is_empty() {
+            body.push('\n');
+        }
+        body.push_str(&deferred_namespace_imports);
+        body.push('\n');
+    }
+
     let child_modules: Vec<String> = module
         .submodules
         .values()
@@ -2245,21 +2478,6 @@ fn render_module_file(
         for child in &child_modules {
             body.push_str(&format!("from . import {child}\n"));
         }
-    }
-
-    if ns_path.len() == 1 {
-        if !body.trim().is_empty() {
-            body.push('\n');
-        }
-        // Suppress only `ImportError` (which can occur if the
-        // namespace is imported standalone before the root package
-        // finishes initialising) — let `model_rebuild()` failures
-        // propagate so dangling references surface at import time.
-        body.push_str("try:\n");
-        body.push_str("    from .._rebuild import rebuild_models as _rebuild_models\n\n");
-        body.push_str("    _rebuild_models()\n");
-        body.push_str("except ImportError:\n");
-        body.push_str("    pass\n");
     }
 
     let mut all_names: BTreeSet<String> = aliases.into_keys().collect();
@@ -2568,17 +2786,17 @@ fn render_package_files(
             .map(|mt| mt.rendered.as_str())
             .collect::<Vec<_>>()
             .join("\n\n");
+        let root_namespace_bindings =
+            render_root_type_namespace_bindings(&generation, &root_types_code);
+        let mut root_type_parts = vec![generation.preamble.clone()];
+        if !root_namespace_bindings.is_empty() {
+            root_type_parts.push(root_namespace_bindings);
+        }
+        root_type_parts.push(render_external_type_aliases());
+        root_type_parts.push(root_types_code);
         files.insert(
             "_types.py".to_string(),
-            render_python_file(
-                config,
-                [
-                    generation.preamble.clone(),
-                    render_external_type_aliases(),
-                    root_types_code,
-                ]
-                .join("\n\n"),
-            )?,
+            render_python_file(config, root_type_parts.join("\n\n"))?,
         );
     }
 
@@ -5428,10 +5646,13 @@ pub mod templates {
             // time). `is_pydantic_method_name` already renames the
             // exact-match collisions; this kills the warning for the
             // remaining safe-but-prefixed cases.
+            // `defer_build=True` lets the generated package finish
+            // importing all namespace modules before Pydantic resolves
+            // annotations; `_rebuild.py` then performs a strict rebuild.
             let config = if self.is_partial() {
-                "ConfigDict(extra=\"ignore\", populate_by_name=True, validate_assignment=True, protected_namespaces=())"
+                "ConfigDict(extra=\"ignore\", populate_by_name=True, validate_assignment=True, protected_namespaces=(), defer_build=True)"
             } else {
-                "ConfigDict(extra=\"ignore\", populate_by_name=True, protected_namespaces=())"
+                "ConfigDict(extra=\"ignore\", populate_by_name=True, protected_namespaces=(), defer_build=True)"
             };
             writeln!(s, "    model_config = {config}").unwrap();
             writeln!(s).unwrap();
@@ -6136,7 +6357,7 @@ pub mod templates {
             }
             writeln!(
                 s,
-                "    model_config = ConfigDict(extra=\"ignore\", protected_namespaces=())"
+                "    model_config = ConfigDict(extra=\"ignore\", protected_namespaces=(), defer_build=True)"
             )
             .unwrap();
             writeln!(s).unwrap();
@@ -6192,7 +6413,7 @@ pub mod templates {
             writeln!(s).unwrap();
             writeln!(
                 s,
-                "    model_config = ConfigDict(extra=\"ignore\", protected_namespaces=())"
+                "    model_config = ConfigDict(extra=\"ignore\", protected_namespaces=(), defer_build=True)"
             )
             .unwrap();
             writeln!(s).unwrap();
@@ -6263,7 +6484,7 @@ pub mod templates {
             }
             writeln!(
                 s,
-                "    model_config = ConfigDict(extra=\"ignore\", protected_namespaces=())"
+                "    model_config = ConfigDict(extra=\"ignore\", protected_namespaces=(), defer_build=True)"
             )
             .unwrap();
             writeln!(s).unwrap();

--- a/reflectapi/src/codegen/python.rs
+++ b/reflectapi/src/codegen/python.rs
@@ -3208,6 +3208,7 @@ fn collect_flattened_fields(
 }
 
 /// Create a single flattened field entry from a struct field
+#[allow(clippy::too_many_arguments)]
 fn make_flattened_field(
     field: &reflectapi_schema::Field,
     schema: &Schema,


### PR DESCRIPTION
## Summary

- Escape embedded double quotes in generated Python docstrings so schema descriptions cannot break string literals.
- Fix split Python namespace generation so child and peer namespace aliases are bound before generated model classes need them.
- Defer Pydantic model rebuilds until package-level imports have loaded the generated modules.
- Refresh the generated demo Python client and accepted snapshots affected by the deferred-model output.

## Why

Generated Python clients could fail to import when schemas contained quote-heavy descriptions or when generated type hints crossed split namespace modules. The namespace issue shows up in larger clients where a model references a child or peer namespace before that namespace has been imported and rebound in the package.

## Coverage

- Regression coverage for docstring quote escaping.
- Regression coverage for child namespace binding, peer namespace cycles, namespace aliases in generated references, builtin-shadowing namespace names such as `input`, and deferred model rebuilds.
- Demo generated Python client snapshot plus Rust and Python snapshot updates to keep codegen drift checks honest.

## Validation

- GitHub Actions on `ee6016f`: Rust format, lint, and test; Python runtime tests; Python codegen smoke test; documentation examples; and documentation preview all passed. The docs deploy job is skipped as expected for this PR.
- Local validation used while preparing the branch: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, and importing the generated demo Python client.

Fixes #156.

