### PR TITLE
chore: release 0.17.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 Python client generation improvements:
 
-- Python codegen still falls back to basic formatting when Ruff is not installed, but now reports an error if `ruff format` is available and fails; pass `--format=false` to skip external formatting.
+- Python codegen still falls back to basic formatting when Ruff is not installed, but now reports a clear error — including the formatter's own exit status and output — if `ruff format` is available and fails; pass `--format=false` to skip external formatting.
 - Multi-field Rust tuple structs now generate valid Python `RootModel[tuple[...]]` models instead of invalid numeric field names.
 - Generated Python clients with nested namespaces now import cleanly when models refer to parent or sibling namespaces, including cases like `offer_rules.InsurerCategory`.
 - Namespace names containing characters that are not valid in Python identifiers, such as dashes or leading digits, now generate valid Python classes.
-- A root type and a same-leaf type under a sub-namespace (e.g. `IfConflictOnUpdate` and `nomatches::IfConflictOnUpdate`) no longer collide on a bare public name. Previously each namespace re-emitted a `<Leaf> = <NamespacePrefixedLeaf>` alias that shadowed the `from .._types import <Leaf>` it also imported, so `_types.<Leaf>` and `<ns>.<Leaf>` resolved to two different classes and field annotations silently bound to the wrong one (pydantic then rejected values with a confusingly self-identical error). The namespace-local type now keeps its disambiguated name (`NomatchesIfConflictOnUpdate`) and references resolve to a single class per logical type.
+- Fixed generated clients silently using the wrong class when a sub-namespace defined a type whose name matched a top-level type (e.g. a top-level `IfConflictOnUpdate` and a `nomatches::IfConflictOnUpdate`). The two were emitted as separate classes sharing one name, so a value built with one was rejected by the other at runtime with a confusingly self-identical pydantic validation error. Each logical type now resolves to a single class: when names would clash, the sub-namespace type is exposed under a namespace-qualified name (e.g. `nomatches.NomatchesIfConflictOnUpdate`) while the short name (`nomatches.IfConflictOnUpdate`) refers to the top-level type.
 - Schemas with a root namespace named `sys` no longer conflict with Python's standard `sys` module.
 - Re-running `reflectapi codegen` into an existing output directory now removes generated files from older schemas while preserving hand-written files.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.17.5
 
 Python client generation improvements:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi-cli"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi-derive"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi-schema"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "glob",
  "serde",

--- a/reflectapi-cli/Cargo.toml
+++ b/reflectapi-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi-cli"
-version = "0.17.4"
+version = "0.17.5"
 edition = "2021"
 default-run = "reflectapi"
 
@@ -23,7 +23,7 @@ doc = false
 workspace = true
 
 [dependencies]
-reflectapi = { path = "../reflectapi", version = "0.17.4", features = ["codegen"] }
+reflectapi = { path = "../reflectapi", version = "0.17.5", features = ["codegen"] }
 rouille = "3"
 
 clap = { version = "4.5.3", features = ["derive"] }

--- a/reflectapi-derive/Cargo.toml
+++ b/reflectapi-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi-derive"
-version = "0.17.4"
+version = "0.17.5"
 edition = "2021"
 
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ workspace = true
 proc-macro = true
 
 [dependencies]
-reflectapi-schema = { path = '../reflectapi-schema', version = "0.17.4" }
+reflectapi-schema = { path = '../reflectapi-schema', version = "0.17.5" }
 
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/reflectapi-python-runtime/pyproject.toml
+++ b/reflectapi-python-runtime/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "reflectapi-runtime"
-version = "0.17.4"
+version = "0.17.5"
 description = "Runtime library for ReflectAPI Python clients"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/reflectapi-python-runtime/src/reflectapi_runtime/__init__.py
+++ b/reflectapi-python-runtime/src/reflectapi_runtime/__init__.py
@@ -50,7 +50,7 @@ from .testing import (
 )
 from .types import BatchResult, ReflectapiEmpty, ReflectapiInfallible
 
-__version__ = "0.17.4"
+__version__ = "0.17.5"
 
 __all__ = [
     # Authentication

--- a/reflectapi-schema/Cargo.toml
+++ b/reflectapi-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi-schema"
-version = "0.17.4"
+version = "0.17.5"
 edition = "2021"
 
 license = "Apache-2.0"

--- a/reflectapi/Cargo.toml
+++ b/reflectapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi"
-version = "0.17.4"
+version = "0.17.5"
 edition = "2021"
 
 license = "Apache-2.0"
@@ -20,8 +20,8 @@ workspace = true
 
 [dependencies]
 # workspace dependencies
-reflectapi-derive = { path = "../reflectapi-derive", version = "0.17.4" }
-reflectapi-schema = { path = "../reflectapi-schema", version = "0.17.4" }
+reflectapi-derive = { path = "../reflectapi-derive", version = "0.17.5" }
+reflectapi-schema = { path = "../reflectapi-schema", version = "0.17.5" }
 
 # mandatory 3rd party dependencies
 serde = { version = "1.0.197", features = ["derive"] }


### PR DESCRIPTION
Patch release **0.17.5**.

Bumps all workspace crates and the Python runtime to `0.17.5` (versions kept in lockstep, as the release `version-check` requires) and promotes the `Unreleased` CHANGELOG section to `## 0.17.5`.

### Included since 0.17.4
Python client generation improvements (see CHANGELOG), headlined by:
- **#161** — a root type and a same-leaf type under a sub-namespace no longer collide on a bare public name; references now resolve to a single class per logical type (#162).
- Ruff-required formatting error reporting, tuple-struct `RootModel` fix, nested-namespace imports, identifier-safe namespace names, `sys` root namespace, stale-file cleanup.

### Files
- `reflectapi`, `reflectapi-cli`, `reflectapi-derive`, `reflectapi-schema` `Cargo.toml` + internal dep pins
- `reflectapi-python-runtime` `pyproject.toml` + `__version__`
- `Cargo.lock`, `CHANGELOG.md`

### Release process
Versions match across all five files the `version-check` job validates. After merge, pushing the `v0.17.5` tag triggers the publish workflow (crates.io + PyPI + GitHub Release).