### PR TITLE
chore: release 0.17.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## Unreleased
+## 0.17.6
 
+- New `#[reflectapi(hidden)]` field attribute: the field stays in the schema (marked `"hidden": true`) and remains functional at runtime (e.g. header extraction by the axum adapter), but is excluded from generated clients, documentation, and OpenAPI specs. Not allowed on unnamed (tuple) fields, since removing a positional element would shift indices and break wire compatibility.
+- Python codegen now emits nullable `Option<T>` fields as optional keys (`T | None = None`) in the per-variant models generated for structs with a flattened internally-tagged enum, matching the standalone-struct behavior. Previously such fields were required keys, so deserializing a valid payload that omitted the key (serde drops `None` values) raised `pydantic.ValidationError: Field required`. Doubled `str | None | None` annotations in the same paths are also fixed.
+- Python codegen is now snapshot-tested by the same builder test samples as the other language backends.
 - Python package codegen now emits sibling submodule imports in dependency order, so Python 3.14/Pydantic can import generated packages where one sibling model annotation references another sibling namespace.
 - Rust codegen snapshot typechecking now handles macOS proc-macro library names instead of assuming Linux-style `.so` files.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi-cli"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi-derive"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "reflectapi-schema"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "glob",
  "serde",

--- a/reflectapi-cli/Cargo.toml
+++ b/reflectapi-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi-cli"
-version = "0.17.5"
+version = "0.17.6"
 edition = "2021"
 default-run = "reflectapi"
 
@@ -23,7 +23,7 @@ doc = false
 workspace = true
 
 [dependencies]
-reflectapi = { path = "../reflectapi", version = "0.17.5", features = ["codegen"] }
+reflectapi = { path = "../reflectapi", version = "0.17.6", features = ["codegen"] }
 rouille = "3"
 
 clap = { version = "4.5.3", features = ["derive"] }

--- a/reflectapi-derive/Cargo.toml
+++ b/reflectapi-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi-derive"
-version = "0.17.5"
+version = "0.17.6"
 edition = "2021"
 
 license = "Apache-2.0"
@@ -22,7 +22,7 @@ workspace = true
 proc-macro = true
 
 [dependencies]
-reflectapi-schema = { path = '../reflectapi-schema', version = "0.17.5" }
+reflectapi-schema = { path = '../reflectapi-schema', version = "0.17.6" }
 
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/reflectapi-python-runtime/pyproject.toml
+++ b/reflectapi-python-runtime/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "reflectapi-runtime"
-version = "0.17.5"
+version = "0.17.6"
 description = "Runtime library for ReflectAPI Python clients"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/reflectapi-python-runtime/src/reflectapi_runtime/__init__.py
+++ b/reflectapi-python-runtime/src/reflectapi_runtime/__init__.py
@@ -50,7 +50,7 @@ from .testing import (
 )
 from .types import BatchResult, ReflectapiEmpty, ReflectapiInfallible
 
-__version__ = "0.17.5"
+__version__ = "0.17.6"
 
 __all__ = [
     # Authentication

--- a/reflectapi-schema/Cargo.toml
+++ b/reflectapi-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi-schema"
-version = "0.17.5"
+version = "0.17.6"
 edition = "2021"
 
 license = "Apache-2.0"

--- a/reflectapi/Cargo.toml
+++ b/reflectapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reflectapi"
-version = "0.17.5"
+version = "0.17.6"
 edition = "2021"
 
 license = "Apache-2.0"
@@ -20,8 +20,8 @@ workspace = true
 
 [dependencies]
 # workspace dependencies
-reflectapi-derive = { path = "../reflectapi-derive", version = "0.17.5" }
-reflectapi-schema = { path = "../reflectapi-schema", version = "0.17.5" }
+reflectapi-derive = { path = "../reflectapi-derive", version = "0.17.6" }
+reflectapi-schema = { path = "../reflectapi-schema", version = "0.17.6" }
 
 # mandatory 3rd party dependencies
 serde = { version = "1.0.197", features = ["derive"] }


### PR DESCRIPTION
Patch release bumping all workspace crates and the Python runtime to 0.17.6, promoting the Unreleased CHANGELOG section.

## Included since 0.17.5

- `#[reflectapi(hidden)]` field attribute (#168)
- Python codegen: nullable `Option<T>` fields in flattened internally-tagged-enum variant models are now optional keys with a `None` default (#170, fixes #167)
- Python codegen covered by the builder test samples like the other backends (#170)
- Python submodule imports emitted in dependency order (#165)
- macOS proc-macro library names in Rust codegen snapshot typechecking