### PR TITLE
ci: bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Rust format, lint, and test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # NOTE: When updating the biome version, also update reflectapi/src/codegen/typescript.rs
       - uses: biomejs/setup-biome@v2
         with:
@@ -34,7 +34,7 @@ jobs:
     name: Python runtime tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v3
       - name: Run tests
         working-directory: reflectapi-python-runtime
@@ -49,7 +49,7 @@ jobs:
     name: Python codegen smoke test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: astral-sh/setup-uv@v3

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
       - name: Cache Rust dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -41,7 +41,7 @@ jobs:
           mdbook build
           
       - name: Deploy to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -50,7 +50,7 @@ jobs:
           workingDirectory: docs
         
       - name: Update PR comment with preview URL
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         if: github.event_name == 'pull_request'
         with:
           script: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,12 +12,12 @@ jobs:
     name: Test Documentation Examples
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -58,13 +58,13 @@ jobs:
     if: github.ref == 'refs/heads/main'
       
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       
       - name: Cache Rust dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -87,7 +87,7 @@ jobs:
           mdbook build
           
       - name: Deploy to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,8 @@ jobs:
     name: Verify version consistency
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Tag matches all package versions
@@ -119,7 +119,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: rust-lang/crates-io-auth-action@v1
@@ -164,8 +164,8 @@ jobs:
     needs: [version-check]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Build sdist + wheel
@@ -173,7 +173,7 @@ jobs:
         run: |
           python -m pip install --upgrade build
           python -m build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: python-runtime-dist
           path: reflectapi-python-runtime/dist/*
@@ -190,7 +190,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: python-runtime-dist
           path: dist/
@@ -204,8 +204,8 @@ jobs:
     needs: [publish-crates, publish-pypi]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           name: python-runtime-dist
           path: dist/


### PR DESCRIPTION
GitHub forces Node.js 20 actions to run on Node 24 starting **June 16th, 2026** (five days away) and removes Node 20 from runners in September 2026 — the v0.17.6 release run was already emitting deprecation warnings for `checkout`, `setup-python`, `upload-artifact`, and `download-artifact`.

This bumps every pinned action to its current major, all of which run `node24` natively (verified against each action's `action.yml`):

| Action | From | To | Compatibility notes |
|---|---|---|---|
| `actions/checkout` | v4 | v6 | v6 persists credentials to a separate file — irrelevant here, no workflow does `git push` after checkout |
| `actions/setup-python` | v5 | v6 | node24 only |
| `actions/upload-artifact` | v4 | v7 | new `archive` input unused; ESM change is internal |
| `actions/download-artifact` | v4 | v8 | v5's by-**ID** path change and v8's direct-download handling don't apply — both usages download by name with an explicit `path:` |
| `actions/setup-node` | v4 | v6 | v5's auto-caching triggers only on a `packageManager` field in package.json; none at repo root |
| `actions/github-script` | v7 | v9 | v9's ESM breaks `require('@actions/github')` — our script only uses the injected `github`/`context` objects |
| `actions/cache` | v3 | v5 | node24 only, same inputs |
| `cloudflare/wrangler-action` | v3 | v4 | only change is default wrangler version; both usages pin `wranglerVersion: "4.32.0"` |

Left as-is: `Swatinem/rust-cache@v2` and `rust-lang/crates-io-auth-action@v1` (floating major tags already resolve to node24 releases), `dtolnay/rust-toolchain` (composite action, no Node runtime), `pypa/gh-action-pypi-publish@release/v1` (docker action).

Note: this PR's CI exercises `ci.yaml` and the docs workflows (including the github-script PR comment), but `release.yml` only runs on tags — it gets its first real validation on the next release.